### PR TITLE
fixed bug in getLeadingScorer query

### DIFF
--- a/pages/Teams/team-profile-page.cfm
+++ b/pages/Teams/team-profile-page.cfm
@@ -94,7 +94,7 @@
   JOIN teams t ON ps.teamID = t.teamID
   JOIN players p ON p.PlayerID = ps.PlayerID
   JOIN MaxPointsPerSeason mps ON s.SeasonName = mps.SeasonName
-  WHERE ps.Points = mps.MaxPoints AND t.teamID = <cfqueryparam cfsqltype="INTEGER" value="#url.teamID#">;
+  WHERE ps.Points = mps.MaxPoints AND t.teamID = <cfqueryparam cfsqltype="INTEGER" value="#url.teamID#">
 </cfquery>
 
 <cfset playoffsObject = createObject("component", "library.playoffs") />


### PR DESCRIPTION
Fixed the bug revolving around the leading scorer in franchise page. This code should spit out the correct leading scorer who scored the most points for that season.