### PR TITLE
Add live score updates to StatsApp for regular season games

### DIFF
--- a/pages/StatsApp/StatsApp-Save.cfm
+++ b/pages/StatsApp/StatsApp-Save.cfm
@@ -74,10 +74,11 @@
     <cfif scoresExist.homeScore EQ ''>
 
         <cfquery name="updateScheduleScore" datasource="roundleague">
-            UPDATE schedule 
-            SET 
-                    homeScore = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#form.homeScore#">, 
-                    awayScore = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#form.awayScore#">
+            UPDATE schedule
+            SET
+                    homeScore = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#form.homeScore#">,
+                    awayScore = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#form.awayScore#">,
+                    status = 'final'
             WHERE scheduleID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">
         </cfquery>
 

--- a/pages/StatsApp/StatsApp.cfm
+++ b/pages/StatsApp/StatsApp.cfm
@@ -283,7 +283,18 @@
     <script src="https://code.jquery.com/jquery-3.6.0.min.js" crossorigin="anonymous"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.min.js" crossorigin="anonymous"></script>
     <script src="https://kit.fontawesome.com/356f7c17e2.js" crossorigin="anonymous"></script>
-    <script src="StatsApp.js?v=1.4"></script>
+
+    <cfif url.isPlayoffs NEQ 1>
+    <script>
+    var LIVE_SCORE_CONFIG = {
+      scheduleID: '#url.scheduleID#',
+      adminKey: '#application.adminApiKey#',
+      isHome: #(url.teamID EQ getTeamsPlaying.homeTeamID ? 'true' : 'false')#
+    };
+    </script>
+    </cfif>
+
+    <script src="StatsApp.js?v=1.6"></script>
     <script src="StatsApp-Export.js"></script>
     <script src="ConfirmExit.js"></script>
 </body>

--- a/pages/StatsApp/StatsApp.js
+++ b/pages/StatsApp/StatsApp.js
@@ -479,3 +479,66 @@ document.addEventListener("click", function (e) {
     updateSubButton();
   }
 });
+
+/* ============================================================
+ * Live Score Updates
+ *
+ * Fires a PATCH to the Node.js API to keep the mobile app
+ * in sync during a game. Two things happen:
+ *
+ *   1. On page load — marks the game status as 'live' so the
+ *      app shows a LIVE badge within its next 60s poll.
+ *
+ *   2. On every point change — a MutationObserver watches the
+ *      teamTotalPts span (updated by addToValue in real time).
+ *      Whenever it changes, the current team's score is sent.
+ *      isHome determines whether to send homeScore or awayScore.
+ *
+ * Config is injected by StatsApp.cfm as LIVE_SCORE_CONFIG.
+ * The block is skipped entirely for playoff games (config absent).
+ * Status is set to 'final' by StatsApp-Save.cfm on form submit.
+ * ============================================================ */
+(function () {
+  console.log(
+    "LIVE_SCORE_CONFIG: ",
+    typeof LIVE_SCORE_CONFIG === "undefined" ? "undefined" : LIVE_SCORE_CONFIG,
+  );
+  if (typeof LIVE_SCORE_CONFIG === "undefined") return;
+
+  var cfg = LIVE_SCORE_CONFIG;
+  var API_BASE = "http://localhost:3001/api";
+
+  function patchScore(body) {
+    fetch(API_BASE + "/schedule/" + cfg.scheduleID + "/score", {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+        "x-admin-key": cfg.adminKey,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  // Mark game as live on page load
+  patchScore({ status: "live" });
+
+  // Watch teamTotalPts for any point change and send the updated score
+  // Wrapped in ready() because the table is rendered by CFML after this script loads
+  $(document).ready(function () {
+    var totalPtsEl = document.querySelector(".teamTotalPts");
+    if (totalPtsEl) {
+      console.log("Setting up MutationObserver for live score updates...");
+      var observer = new MutationObserver(function () {
+        var score = parseInt(totalPtsEl.textContent) || 0;
+        var body = cfg.isHome ? { homeScore: score } : { awayScore: score };
+        patchScore(body);
+      });
+
+      observer.observe(totalPtsEl, {
+        childList: true,
+        characterData: true,
+        subtree: true,
+      });
+    }
+  });
+})();


### PR DESCRIPTION
- StatsApp.cfm injects LIVE_SCORE_CONFIG (scheduleID, adminKey, isHome) before StatsApp.js loads; skipped entirely for playoffs
- StatsApp.js IIFE marks game live on page load, MutationObserver on teamTotalPts fires PATCH on every point change
- StatsApp-Save.cfm adds status = 'final' to the existing score UPDATE query
- JS cache busted via v=1.6