### PR TITLE
Play-by-play log: real-time stat logging, P-B-P tab on box score, async recap

### DIFF
--- a/pages/StatsApp/StatsApp-LogPlay.cfm
+++ b/pages/StatsApp/StatsApp-LogPlay.cfm
@@ -1,0 +1,53 @@
+<cfsetting showdebugoutput="false">
+<cfcontent type="application/json">
+
+<cfparam name="form.action"                  default="">
+<cfparam name="form.scheduleID"              default="0">
+<cfparam name="form.playerID"               default="0">
+<cfparam name="form.teamID"                 default="0">
+<cfparam name="form.stat_type"              default="">
+<cfparam name="form.points_scored"          default="0">
+<cfparam name="form.home_score"             default="0">
+<cfparam name="form.away_score"             default="0">
+<cfparam name="form.period"                 default="1">
+<cfparam name="form.clock_remaining_seconds" default="">
+<cfparam name="form.local_play_id"          default="">
+
+<cftry>
+    <cfif form.action EQ "add" AND len(trim(form.local_play_id)) AND val(form.scheduleID) GT 0>
+        <cfquery datasource="roundleague">
+            INSERT IGNORE INTO game_plays
+                (scheduleID, playerID, teamID, stat_type, points_scored,
+                 home_score, away_score, period, clock_remaining_seconds, local_play_id)
+            VALUES (
+                <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#val(form.scheduleID)#">,
+                <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#val(form.playerID)#">,
+                <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#val(form.teamID)#">,
+                <cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#left(trim(form.stat_type), 20)#">,
+                <cfqueryparam cfsqltype="CF_SQL_TINYINT" value="#val(form.points_scored)#">,
+                <cfqueryparam cfsqltype="CF_SQL_SMALLINT" value="#val(form.home_score)#">,
+                <cfqueryparam cfsqltype="CF_SQL_SMALLINT" value="#val(form.away_score)#">,
+                <cfqueryparam cfsqltype="CF_SQL_TINYINT" value="#val(form.period)#">,
+                <cfif len(trim(form.clock_remaining_seconds)) AND isNumeric(form.clock_remaining_seconds)>
+                    <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#val(form.clock_remaining_seconds)#">
+                <cfelse>
+                    NULL
+                </cfif>,
+                <cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#left(trim(form.local_play_id), 60)#">
+            )
+        </cfquery>
+
+    <cfelseif form.action EQ "remove" AND len(trim(form.local_play_id)) AND val(form.scheduleID) GT 0>
+        <cfquery datasource="roundleague">
+            UPDATE game_plays
+            SET is_removed = 1
+            WHERE scheduleID  = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#val(form.scheduleID)#">
+              AND local_play_id = <cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#left(trim(form.local_play_id), 60)#">
+        </cfquery>
+    </cfif>
+
+    <cfoutput>{"ok":true}</cfoutput>
+<cfcatch>
+    <cfoutput>{"ok":false}</cfoutput>
+</cfcatch>
+</cftry>

--- a/pages/StatsApp/StatsApp-Save.cfm
+++ b/pages/StatsApp/StatsApp-Save.cfm
@@ -243,30 +243,40 @@
             <cfset recapTotalMessage = recapFirstTeamTotals & recapSecondTeamTotals & recapTeamScores & recapPlayerPrompts>
 
             <cfinclude template="/pages/boxscore/config.cfm">
-            <cfhttp url="https://api.openai.com/v1/chat/completions" method="POST" result="recapHttpResult">
-                <cfhttpparam type="header" name="Content-Type" value="application/json">
-                <cfhttpparam type="header" name="Authorization" value="Bearer #apiKey#">
-                <cfhttpparam type="body" value='{
-                  "model": "gpt-3.5-turbo",
-                  "messages": [
-                    {"role":"system","content":"Recap this basketball game like ESPN would based on the following stats in less than 1000 characters. Majority sentences should highlight individual performances but make sure one sentence compares team totals."},
-                    {"role":"user","content":"#JSStringFormat(recapTotalMessage)#"}
-                  ],
-                  "temperature": 1.0,
-                  "top_p": 1
-                }'>
-            </cfhttp>
 
-            <cfset recapApiResponse = DeserializeJSON(recapHttpResult.fileContent)>
-            <cfif structKeyExists(recapApiResponse, "choices") AND arrayLen(recapApiResponse.choices)>
-                <cfquery name="insertGameRecap" datasource="roundleague">
-                    INSERT INTO recaps (scheduleID, recapText)
-                    VALUES (
-                        <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">,
-                        <cfqueryparam cfsqltype="cf_sql_longvarchar" value="#recapApiResponse.choices[1].message.content#">
-                    )
-                </cfquery>
-            </cfif>
+            <!--- Fire recap generation in background — main request redirects immediately --->
+            <cfthread action="run" name="recap_#url.scheduleID#_#getTickCount()#"
+                      scheduleID="#url.scheduleID#"
+                      totalMessage="#recapTotalMessage#"
+                      openAiKey="#apiKey#">
+                <cftry>
+                    <cfhttp url="https://api.openai.com/v1/chat/completions" method="POST" result="tRecapResult">
+                        <cfhttpparam type="header" name="Content-Type" value="application/json">
+                        <cfhttpparam type="header" name="Authorization" value="Bearer #attributes.openAiKey#">
+                        <cfhttpparam type="body" value='{
+                          "model": "gpt-3.5-turbo",
+                          "messages": [
+                            {"role":"system","content":"Recap this basketball game like ESPN would based on the following stats in less than 1000 characters. Majority sentences should highlight individual performances but make sure one sentence compares team totals."},
+                            {"role":"user","content":"#JSStringFormat(attributes.totalMessage)#"}
+                          ],
+                          "temperature": 1.0,
+                          "top_p": 1
+                        }'>
+                    </cfhttp>
+                    <cfset tRecapParsed = DeserializeJSON(tRecapResult.fileContent)>
+                    <cfif structKeyExists(tRecapParsed, "choices") AND arrayLen(tRecapParsed.choices)>
+                        <cfquery datasource="roundleague">
+                            INSERT INTO recaps (scheduleID, recapText)
+                            VALUES (
+                                <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#attributes.scheduleID#">,
+                                <cfqueryparam cfsqltype="cf_sql_longvarchar" value="#tRecapParsed.choices[1].message.content#">
+                            )
+                        </cfquery>
+                    </cfif>
+                <cfcatch></cfcatch>
+                </cftry>
+            </cfthread>
+            <!--- No cfthread join — redirect happens while recap generates in background --->
         </cfif>
     </cfif>
 

--- a/pages/StatsApp/StatsApp.js
+++ b/pages/StatsApp/StatsApp.js
@@ -150,8 +150,10 @@ $(document).ready(function () {
     // Push to globalHistory
     var undoNode = $(addNode).siblings(".button-error");
     globalHistory.push(undoNode);
+    var logEntry = null;
     if (!suppressLogPush) {
-      actionLog.push(buildLogEntry(category, undoNode));
+      logEntry = buildLogEntry(category, undoNode);
+      actionLog.push(logEntry);
       saveLogToStorage();
     }
 
@@ -179,12 +181,15 @@ $(document).ready(function () {
       addToValue("PTS", 1, playerID);
       addToValue("FTA", 1, playerID);
     }
+
+    if (logEntry) { try { persistPlay(logEntry, playerID); } catch(e) {} }
   }
 
   $(".button-success").click(function () {
     // Push to globalHistory
     var undoNode = $(this).siblings(".button-error");
     globalHistory.push(undoNode);
+    var logEntry = null;
     if (!suppressLogPush) {
       var btnClasses = $(this).attr('class').split(' ');
       var knownStats = ['FGM','3FGM','FGA','3FGA','REBS','ASTS','STLS','BLKS','TO','FOULS','FTM','FTA','PTS'];
@@ -192,7 +197,8 @@ $(document).ready(function () {
       for (var si = 0; si < btnClasses.length; si++) {
         if (knownStats.indexOf(btnClasses[si]) !== -1) { logStat = btnClasses[si]; break; }
       }
-      actionLog.push(buildLogEntry(logStat, undoNode));
+      logEntry = buildLogEntry(logStat, undoNode);
+      actionLog.push(logEntry);
       saveLogToStorage();
     }
 
@@ -222,6 +228,8 @@ $(document).ready(function () {
       $(".Fouls_Half_" + currentHalf).html(currentNum);
       patchFouls(currentHalf);
     }
+
+    if (logEntry) { try { persistPlay(logEntry, playerID); } catch(e) {} }
   });
 
   $(document).keydown(function (e) {
@@ -454,6 +462,56 @@ $(document).ready(function () {
     try { localStorage.setItem(logStorageKey, JSON.stringify(serialized)); } catch(err) {}
   }
 
+  function persistPlay(entry, playerIDStr) {
+    if (!window.RL_LOG_CONFIG) return;
+    var cfg = window.RL_LOG_CONFIG;
+    var pointsMap = { FGM: 2, '3FGM': 3, FTM: 1 };
+    var points = pointsMap[entry.stat] || 0;
+    var periodEl = document.getElementById('clockPeriodLabel');
+    var periodNum = periodEl ? (parseInt(periodEl.textContent) || 1) : 1;
+    var numericPlayerID = parseInt((playerIDStr || '').replace(/\D/g, ''), 10) || 0;
+    var homeScore = 0, awayScore = 0;
+    if (window.currentScores) {
+      homeScore = window.currentScores.homeScore || 0;
+      awayScore = window.currentScores.awayScore || 0;
+    }
+    var domScore = parseInt($('.teamTotalPts').text()) || 0;
+    if (window.LIVE_SCORE_CONFIG) {
+      if (window.LIVE_SCORE_CONFIG.isHome) homeScore = domScore;
+      else awayScore = domScore;
+    }
+    fetch('/pages/StatsApp/StatsApp-LogPlay.cfm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        action: 'add',
+        scheduleID: cfg.scheduleID,
+        teamID: cfg.teamID,
+        playerID: numericPlayerID,
+        stat_type: entry.stat || '',
+        points_scored: points,
+        home_score: homeScore,
+        away_score: awayScore,
+        period: periodNum,
+        local_play_id: entry.id
+      })
+    }).catch(function() {});
+  }
+
+  function persistRemovePlay(localPlayID) {
+    if (!window.RL_LOG_CONFIG) return;
+    var cfg = window.RL_LOG_CONFIG;
+    fetch('/pages/StatsApp/StatsApp-LogPlay.cfm', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        action: 'remove',
+        scheduleID: cfg.scheduleID,
+        local_play_id: localPlayID
+      })
+    }).catch(function() {});
+  }
+
   function loadLogFromStorage() {
     if (!logStorageKey) return;
     try {
@@ -478,6 +536,7 @@ $(document).ready(function () {
       if (ghIdx !== -1) globalHistory.splice(ghIdx, 1);
     }
     entry.removed = true;
+    try { persistRemovePlay(entry.id); } catch(e) {}
     saveLogToStorage();
     renderLog();
   }

--- a/pages/boxscore/boxscore.cfm
+++ b/pages/boxscore/boxscore.cfm
@@ -143,15 +143,17 @@
 
         <div class="rotateTip">Rotate your device to see the full box score</div>
 
-        <ul class="nav nav-tabs" id="gameTab" style="margin-bottom:16px;">
-            <li class="active"><a href="##boxscore-tab" data-toggle="tab">Box Score</a></li>
-            <li><a href="##playbyplay-tab" data-toggle="tab">Play-By-Play</a></li>
+        <cfset defaultTab = (getPlayerLogs.recordCount EQ 0) ? "playbyplay" : "boxscore">
+
+        <ul class="nav nav-tabs" id="gameTab">
+            <li class="<cfif defaultTab EQ 'boxscore'>active</cfif>"><a href="##boxscore-tab">Box Score</a></li>
+            <li class="<cfif defaultTab EQ 'playbyplay'>active</cfif>"><a href="##playbyplay-tab">Play-By-Play</a></li>
         </ul>
 
         <div class="tab-content">
 
         <!--- Box Score Tab --->
-        <div class="tab-pane active" id="boxscore-tab">
+        <div class="tab-pane <cfif defaultTab EQ 'boxscore'>active</cfif>" id="boxscore-tab">
         <table class="bolder smallFont">
             <cfset currentTeamID = ''>
 
@@ -314,44 +316,46 @@
         </div><!--- end #boxscore-tab --->
 
         <!--- Play-By-Play Tab --->
-        <div class="tab-pane" id="playbyplay-tab">
+        <div class="tab-pane <cfif defaultTab EQ 'playbyplay'>active</cfif>" id="playbyplay-tab">
             <cfif getPlayByPlay.recordCount EQ 0>
-                <p style="color:##888;text-align:center;padding:30px 0;">No scoring plays recorded yet.</p>
+                <p style="color:##888;text-align:center;padding:40px 0;font-size:14px;">No scoring plays recorded yet.</p>
             <cfelse>
-                <table class="pure-table pure-table-striped smallFont" style="width:100%;margin-top:8px;">
+                <table class="pbp-table">
                     <thead>
                         <tr>
-                            <th>Period</th>
-                            <th>Team</th>
-                            <th>Player</th>
-                            <th>Play</th>
-                            <th>Score</th>
+                            <th>PER</th>
+                            <th>TEAM</th>
+                            <th>PLAYER</th>
+                            <th>PLAY</th>
+                            <th style="text-align:right;">SCORE</th>
                         </tr>
                     </thead>
                     <tbody>
                         <cfloop query="getPlayByPlay">
                             <cfif stat_type EQ "FGM">
-                                <cfset playLabel = "2-pt field goal">
+                                <cfset badgeClass = "pbp-badge-2pt">
+                                <cfset badgeText = "2PT">
                             <cfelseif stat_type EQ "3FGM">
-                                <cfset playLabel = "3-pt field goal">
+                                <cfset badgeClass = "pbp-badge-3pt">
+                                <cfset badgeText = "3PT">
                             <cfelseif stat_type EQ "FTM">
-                                <cfset playLabel = "free throw">
+                                <cfset badgeClass = "pbp-badge-ft">
+                                <cfset badgeText = "FT">
                             <cfelse>
-                                <cfset playLabel = stat_type>
+                                <cfset badgeClass = "">
+                                <cfset badgeText = stat_type>
                             </cfif>
                             <tr>
-                                <td>H#period#</td>
-                                <td>#teamName#</td>
-                                <td>#firstName# #lastName#</td>
-                                <td>#playLabel#</td>
-                                <td style="white-space:nowrap;">#home_score# &ndash; #away_score#</td>
+                                <td class="pbp-period">H#period#</td>
+                                <td class="pbp-team">#teamName#</td>
+                                <td class="pbp-player">#firstName# #lastName#</td>
+                                <td><span class="pbp-badge #badgeClass#">#badgeText#</span></td>
+                                <td class="pbp-score">#home_score# &ndash; #away_score#</td>
                             </tr>
                         </cfloop>
                     </tbody>
                 </table>
-                <p style="font-size:.8em;color:##aaa;margin-top:8px;">
-                    #getTeamsPlaying.Home# (home) &ndash; #getTeamsPlaying.Away# (away) &bull; Showing scoring plays only
-                </p>
+                <p class="pbp-legend">#getTeamsPlaying.Home# (home) &bull; #getTeamsPlaying.Away# (away)</p>
             </cfif>
         </div><!--- end ##playbyplay-tab --->
 
@@ -441,5 +445,21 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
 <script src="../boxscore/playerStatsModal.js?v=1.0"></script>
 
+<script>
+(function() {
+    var navLinks = document.querySelectorAll('#gameTab a');
+    var panes    = document.querySelectorAll('.tab-content .tab-pane');
+    navLinks.forEach(function(link) {
+        link.addEventListener('click', function(e) {
+            e.preventDefault();
+            var targetId = this.getAttribute('href').replace('#', '');
+            navLinks.forEach(function(l) { l.parentElement.classList.remove('active'); });
+            this.parentElement.classList.add('active');
+            panes.forEach(function(p) { p.classList.remove('active'); });
+            document.getElementById(targetId).classList.add('active');
+        });
+    });
+})();
+</script>
 <cfinclude template="/footer.cfm">
 <script src="../boxscore/recap.js?v=1.1"></script>

--- a/pages/boxscore/boxscore.cfm
+++ b/pages/boxscore/boxscore.cfm
@@ -41,7 +41,7 @@
 </cfquery>
 
 <cfquery name="getTeamsPlaying" datasource="roundleague">
-    SELECT scheduleID, WEEK, a.teamName AS Home, b.teamName AS Away, s.startTime, Date_FORMAT(s.date, "%M %d, %Y") AS Date, s.homeScore, s.awayscore, a.teamID as HomeTeamID, b.teamID as AwayTeamID
+    SELECT scheduleID, WEEK, a.teamName AS Home, b.teamName AS Away, s.startTime, Date_FORMAT(s.date, "%M %d, %Y") AS Date, s.homeScore, s.awayscore, s.status, a.teamID as HomeTeamID, b.teamID as AwayTeamID
     FROM schedule s
     LEFT JOIN teams as a ON s.hometeamID = a.teamID
     LEFT JOIN teams as b ON s.awayTeamID = b.teamID
@@ -73,7 +73,8 @@
     WHERE gp.scheduleID   = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">
       AND gp.points_scored > 0
       AND gp.is_removed    = 0
-    ORDER BY gp.period ASC, gp.playID ASC
+    ORDER BY
+        <cfif getTeamsPlaying.status EQ 'final'>gp.period ASC, gp.playID ASC<cfelse>gp.period DESC, gp.playID DESC</cfif>
 </cfquery>
 
 <cfset boxscore = createObject("component", "boxscore")>
@@ -321,6 +322,7 @@
                 <p style="color:##888;text-align:center;padding:40px 0;font-size:14px;">No scoring plays recorded yet.</p>
             <cfelse>
                 <cfset pbpCurrentPeriod = "">
+                <cfset pbpOpenBody = false>
                 <table class="pbp-table">
                     <thead>
                         <tr>
@@ -330,37 +332,40 @@
                             <th style="text-align:right;">SCORE</th>
                         </tr>
                     </thead>
-                    <tbody>
-                        <cfloop query="getPlayByPlay">
-                            <cfif period NEQ pbpCurrentPeriod>
-                                <cfset pbpCurrentPeriod = period>
-                                <tr class="pbp-half-header">
-                                    <td colspan="4">
-                                        <cfif period EQ 1>1st Half<cfelseif period EQ 2>2nd Half<cfelse>OT<cfif period GT 3> #period - 2#</cfif></cfif>
-                                    </td>
-                                </tr>
-                            </cfif>
-                            <cfif stat_type EQ "FGM">
-                                <cfset badgeClass = "pbp-badge-2pt">
-                                <cfset badgeText = "2PT">
-                            <cfelseif stat_type EQ "3FGM">
-                                <cfset badgeClass = "pbp-badge-3pt">
-                                <cfset badgeText = "3PT">
-                            <cfelseif stat_type EQ "FTM">
-                                <cfset badgeClass = "pbp-badge-ft">
-                                <cfset badgeText = "FT">
-                            <cfelse>
-                                <cfset badgeClass = "">
-                                <cfset badgeText = stat_type>
-                            </cfif>
-                            <tr>
-                                <td class="pbp-team">#teamName#</td>
-                                <td class="pbp-player">#firstName# #lastName#</td>
-                                <td><span class="pbp-badge #badgeClass#">#badgeText#</span></td>
-                                <td class="pbp-score">#home_score# &ndash; #away_score#</td>
+                    <cfloop query="getPlayByPlay">
+                        <cfif period NEQ pbpCurrentPeriod>
+                            <cfif pbpOpenBody></tbody></cfif>
+                            <cfset pbpCurrentPeriod = period>
+                            <cfset pbpOpenBody = true>
+                            <tbody class="pbp-half-body">
+                            <tr class="pbp-half-header pbp-half-toggle">
+                                <td colspan="4">
+                                    <cfif period EQ 1>1st Half<cfelseif period EQ 2>2nd Half<cfelse>OT<cfif period GT 3> #period - 2#</cfif></cfif>
+                                    <span class="pbp-toggle-icon">&#9660;</span>
+                                </td>
                             </tr>
-                        </cfloop>
-                    </tbody>
+                        </cfif>
+                        <cfif stat_type EQ "FGM">
+                            <cfset badgeClass = "pbp-badge-2pt">
+                            <cfset badgeText = "2PT">
+                        <cfelseif stat_type EQ "3FGM">
+                            <cfset badgeClass = "pbp-badge-3pt">
+                            <cfset badgeText = "3PT">
+                        <cfelseif stat_type EQ "FTM">
+                            <cfset badgeClass = "pbp-badge-ft">
+                            <cfset badgeText = "FT">
+                        <cfelse>
+                            <cfset badgeClass = "">
+                            <cfset badgeText = stat_type>
+                        </cfif>
+                        <tr>
+                            <td class="pbp-team">#teamName#</td>
+                            <td class="pbp-player">#firstName# #lastName#</td>
+                            <td><span class="pbp-badge #badgeClass#">#badgeText#</span></td>
+                            <td class="pbp-score">#home_score# &ndash; #away_score#</td>
+                        </tr>
+                    </cfloop>
+                    <cfif pbpOpenBody></tbody></cfif>
                 </table>
                 <p class="pbp-legend">#getTeamsPlaying.Home# (home) &bull; #getTeamsPlaying.Away# (away)</p>
             </cfif>
@@ -454,6 +459,7 @@
 
 <script>
 (function() {
+    // Tab switching
     var navLinks = document.querySelectorAll('#gameTab a');
     var panes    = document.querySelectorAll('.tab-content .tab-pane');
     navLinks.forEach(function(link) {
@@ -464,6 +470,21 @@
             this.parentElement.classList.add('active');
             panes.forEach(function(p) { p.classList.remove('active'); });
             document.getElementById(targetId).classList.add('active');
+        });
+    });
+
+    // Play-by-play half section toggle
+    document.querySelectorAll('.pbp-half-toggle').forEach(function(header) {
+        header.addEventListener('click', function() {
+            var tbody = this.closest('tbody');
+            var rows = Array.from(tbody.querySelectorAll('tr')).filter(function(r) {
+                return !r.classList.contains('pbp-half-header');
+            });
+            var collapsing = !this.classList.contains('collapsed');
+            rows.forEach(function(r) { r.style.display = collapsing ? 'none' : ''; });
+            this.classList.toggle('collapsed', collapsing);
+            var icon = this.querySelector('.pbp-toggle-icon');
+            if (icon) icon.innerHTML = collapsing ? '&#9654;' : '&#9660;';
         });
     });
 })();

--- a/pages/boxscore/boxscore.cfm
+++ b/pages/boxscore/boxscore.cfm
@@ -341,7 +341,7 @@
                             <tr class="pbp-half-header pbp-half-toggle">
                                 <td colspan="4">
                                     <cfif period EQ 1>1st Half<cfelseif period EQ 2>2nd Half<cfelse>OT<cfif period GT 3> #period - 2#</cfif></cfif>
-                                    <span class="pbp-toggle-icon">&#9660;</span>
+                                    <span class="pbp-toggle-icon">&##9660;</span>
                                 </td>
                             </tr>
                         </cfif>

--- a/pages/boxscore/boxscore.cfm
+++ b/pages/boxscore/boxscore.cfm
@@ -73,7 +73,7 @@
     WHERE gp.scheduleID   = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">
       AND gp.points_scored > 0
       AND gp.is_removed    = 0
-    ORDER BY gp.playID DESC
+    ORDER BY gp.period ASC, gp.playID ASC
 </cfquery>
 
 <cfset boxscore = createObject("component", "boxscore")>
@@ -320,10 +320,10 @@
             <cfif getPlayByPlay.recordCount EQ 0>
                 <p style="color:##888;text-align:center;padding:40px 0;font-size:14px;">No scoring plays recorded yet.</p>
             <cfelse>
+                <cfset pbpCurrentPeriod = "">
                 <table class="pbp-table">
                     <thead>
                         <tr>
-                            <th>PER</th>
                             <th>TEAM</th>
                             <th>PLAYER</th>
                             <th>PLAY</th>
@@ -332,6 +332,14 @@
                     </thead>
                     <tbody>
                         <cfloop query="getPlayByPlay">
+                            <cfif period NEQ pbpCurrentPeriod>
+                                <cfset pbpCurrentPeriod = period>
+                                <tr class="pbp-half-header">
+                                    <td colspan="4">
+                                        <cfif period EQ 1>1st Half<cfelseif period EQ 2>2nd Half<cfelse>OT<cfif period GT 3> #period - 2#</cfif></cfif>
+                                    </td>
+                                </tr>
+                            </cfif>
                             <cfif stat_type EQ "FGM">
                                 <cfset badgeClass = "pbp-badge-2pt">
                                 <cfset badgeText = "2PT">
@@ -346,7 +354,6 @@
                                 <cfset badgeText = stat_type>
                             </cfif>
                             <tr>
-                                <td class="pbp-period">H#period#</td>
                                 <td class="pbp-team">#teamName#</td>
                                 <td class="pbp-player">#firstName# #lastName#</td>
                                 <td><span class="pbp-badge #badgeClass#">#badgeText#</span></td>

--- a/pages/boxscore/boxscore.cfm
+++ b/pages/boxscore/boxscore.cfm
@@ -12,6 +12,9 @@
         DELETE FROM game_subs WHERE scheduleID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">
     </cfquery>
     <cfquery datasource="roundleague">
+        DELETE FROM game_plays WHERE scheduleID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">
+    </cfquery>
+    <cfquery datasource="roundleague">
         UPDATE schedule
         SET homeScore = NULL, awayScore = NULL, status = 'scheduled'
         WHERE scheduleID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">
@@ -20,7 +23,8 @@
 </cfif>
 
 <!--- Page Specific CSS/JS Here --->
-<link href="../boxscore/boxscore.css?v=1.6" rel="stylesheet">
+<cfset _v = getFileInfo(expandPath("/pages/boxscore/boxscore.css")).lastModified.getTime()>
+<link href="/pages/boxscore/boxscore.css?v=<cfoutput>#_v#</cfoutput>" rel="stylesheet">
 <!--- POG-style fonts for player stats modal --->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -57,6 +61,19 @@
     FROM standings
     WHERE teamID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#getTeamsPlaying.AwayTeamID# ">
     AND seasonID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#session.currentSeasonID#">
+</cfquery>
+
+<cfquery name="getPlayByPlay" datasource="roundleague">
+    SELECT gp.playID, gp.stat_type, gp.points_scored,
+           gp.home_score, gp.away_score, gp.period,
+           p.firstName, p.lastName, t.teamName
+    FROM game_plays gp
+    JOIN Players p ON p.playerID = gp.playerID
+    JOIN Teams t   ON t.teamID   = gp.teamID
+    WHERE gp.scheduleID   = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#url.scheduleID#">
+      AND gp.points_scored > 0
+      AND gp.is_removed    = 0
+    ORDER BY gp.playID DESC
 </cfquery>
 
 <cfset boxscore = createObject("component", "boxscore")>
@@ -126,8 +143,15 @@
 
         <div class="rotateTip">Rotate your device to see the full box score</div>
 
-        <!--- End Test --->
+        <ul class="nav nav-tabs" id="gameTab" style="margin-bottom:16px;">
+            <li class="active"><a href="##boxscore-tab" data-toggle="tab">Box Score</a></li>
+            <li><a href="##playbyplay-tab" data-toggle="tab">Play-By-Play</a></li>
+        </ul>
 
+        <div class="tab-content">
+
+        <!--- Box Score Tab --->
+        <div class="tab-pane active" id="boxscore-tab">
         <table class="bolder smallFont">
             <cfset currentTeamID = ''>
 
@@ -287,6 +311,51 @@
                 </cfif>
         	</cfloop>
         </table>
+        </div><!--- end #boxscore-tab --->
+
+        <!--- Play-By-Play Tab --->
+        <div class="tab-pane" id="playbyplay-tab">
+            <cfif getPlayByPlay.recordCount EQ 0>
+                <p style="color:##888;text-align:center;padding:30px 0;">No scoring plays recorded yet.</p>
+            <cfelse>
+                <table class="pure-table pure-table-striped smallFont" style="width:100%;margin-top:8px;">
+                    <thead>
+                        <tr>
+                            <th>Period</th>
+                            <th>Team</th>
+                            <th>Player</th>
+                            <th>Play</th>
+                            <th>Score</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <cfloop query="getPlayByPlay">
+                            <cfif stat_type EQ "FGM">
+                                <cfset playLabel = "2-pt field goal">
+                            <cfelseif stat_type EQ "3FGM">
+                                <cfset playLabel = "3-pt field goal">
+                            <cfelseif stat_type EQ "FTM">
+                                <cfset playLabel = "free throw">
+                            <cfelse>
+                                <cfset playLabel = stat_type>
+                            </cfif>
+                            <tr>
+                                <td>H#period#</td>
+                                <td>#teamName#</td>
+                                <td>#firstName# #lastName#</td>
+                                <td>#playLabel#</td>
+                                <td style="white-space:nowrap;">#home_score# &ndash; #away_score#</td>
+                            </tr>
+                        </cfloop>
+                    </tbody>
+                </table>
+                <p style="font-size:.8em;color:##aaa;margin-top:8px;">
+                    #getTeamsPlaying.Home# (home) &ndash; #getTeamsPlaying.Away# (away) &bull; Showing scoring plays only
+                </p>
+            </cfif>
+        </div><!--- end ##playbyplay-tab --->
+
+        </div><!--- end .tab-content --->
         <br>
         <cfinclude template="recap.cfm">
 

--- a/pages/boxscore/boxscore.css
+++ b/pages/boxscore/boxscore.css
@@ -365,42 +365,152 @@ a.playerLink {
 }
 
 /* ============================================
-   Game tabs — overrides paper-kit nav styles
+   Game tabs — modern underline style
    ============================================ */
 ul#gameTab.nav-tabs {
-	border-bottom: 2px solid #ddd;
-	margin-bottom: 16px;
-	padding-left: 0;
+	border-bottom: 2px solid #e8e8e8;
 	display: flex;
 	justify-content: center;
+	padding: 0;
+	margin-bottom: 24px;
+	list-style: none;
+}
+
+ul#gameTab.nav-tabs > li {
+	margin: 0;
 }
 
 ul#gameTab.nav-tabs > li > a {
-	color: #888;
-	border-radius: 4px 4px 0 0;
-	border: 1px solid transparent;
-	font-weight: 600;
-	font-size: 13px;
-	letter-spacing: 0.5px;
-	text-transform: uppercase;
-	padding: 10px 20px;
-	background: transparent;
 	display: block;
+	padding: 12px 30px;
+	color: #bbb;
+	font-weight: 700;
+	font-size: 11px;
+	letter-spacing: 1.5px;
+	text-transform: uppercase;
+	border: none;
+	border-bottom: 3px solid transparent;
+	margin-bottom: -2px;
+	background: transparent;
+	border-radius: 0;
+	text-decoration: none;
 }
 
 ul#gameTab.nav-tabs > li > a:hover {
-	color: #444;
-	background: #f5f5f5;
-	border-color: #ddd #ddd transparent;
+	color: #555;
+	border-bottom-color: #ccc;
+	background: transparent;
 	text-decoration: none;
 }
 
 ul#gameTab.nav-tabs > li.active > a,
 ul#gameTab.nav-tabs > li.active > a:hover,
 ul#gameTab.nav-tabs > li.active > a:focus {
-	color: #333;
-	background: white;
-	border: 1px solid #ddd;
-	border-bottom-color: white;
+	color: #111;
+	border: none;
+	border-bottom: 3px solid #111;
 	margin-bottom: -2px;
+	background: transparent;
+}
+
+/* ============================================
+   ESPN-style play-by-play table
+   ============================================ */
+.pbp-table {
+	width: 100%;
+	border-collapse: collapse;
+	margin-top: 4px;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+.pbp-table thead tr {
+	background: #111;
+	color: #fff;
+}
+
+.pbp-table thead th {
+	padding: 10px 14px;
+	font-size: 10px;
+	font-weight: 700;
+	letter-spacing: 1.5px;
+	text-transform: uppercase;
+	text-align: left;
+	border: none;
+}
+
+.pbp-table tbody tr {
+	border-bottom: 1px solid #f0f0f0;
+}
+
+.pbp-table tbody tr:hover {
+	background: #fafafa;
+}
+
+.pbp-table tbody td {
+	padding: 12px 14px;
+	vertical-align: middle;
+	border: none;
+}
+
+.pbp-period {
+	font-size: 11px;
+	font-weight: 800;
+	color: #999;
+	letter-spacing: 0.5px;
+	white-space: nowrap;
+}
+
+.pbp-team {
+	font-size: 12px;
+	color: #666;
+	font-weight: 600;
+}
+
+.pbp-player {
+	font-size: 13px;
+	font-weight: 700;
+	color: #111;
+}
+
+.pbp-badge {
+	display: inline-block;
+	padding: 3px 9px;
+	border-radius: 4px;
+	font-size: 10px;
+	font-weight: 800;
+	letter-spacing: 1px;
+	text-transform: uppercase;
+}
+
+.pbp-badge-2pt {
+	background: #e8f5e9;
+	color: #2e7d32;
+}
+
+.pbp-badge-3pt {
+	background: #e3f2fd;
+	color: #1565c0;
+}
+
+.pbp-badge-ft {
+	background: #fff3e0;
+	color: #e65100;
+}
+
+.pbp-score {
+	font-size: 14px;
+	font-weight: 800;
+	color: #111;
+	white-space: nowrap;
+	text-align: right;
+	letter-spacing: -0.5px;
+}
+
+.pbp-legend {
+	font-size: 11px;
+	color: #bbb;
+	text-align: center;
+	margin-top: 14px;
+	padding-bottom: 8px;
+	letter-spacing: 0.3px;
 }

--- a/pages/boxscore/boxscore.css
+++ b/pages/boxscore/boxscore.css
@@ -465,8 +465,24 @@ ul#gameTab.nav-tabs > li.active > a:focus {
 	border-bottom: 1px solid #e0e0e0;
 }
 
-.pbp-half-header:first-child td {
+.pbp-half-body:first-of-type .pbp-half-header td {
 	border-top: none;
+}
+
+.pbp-half-toggle {
+	cursor: pointer;
+	user-select: none;
+}
+
+.pbp-half-toggle:hover td {
+	background: #ebebeb;
+}
+
+.pbp-toggle-icon {
+	float: right;
+	font-size: 9px;
+	color: #aaa;
+	line-height: 1.6;
 }
 
 .pbp-team {

--- a/pages/boxscore/boxscore.css
+++ b/pages/boxscore/boxscore.css
@@ -371,6 +371,8 @@ ul#gameTab.nav-tabs {
 	border-bottom: 2px solid #ddd;
 	margin-bottom: 16px;
 	padding-left: 0;
+	display: flex;
+	justify-content: center;
 }
 
 ul#gameTab.nav-tabs > li > a {

--- a/pages/boxscore/boxscore.css
+++ b/pages/boxscore/boxscore.css
@@ -363,3 +363,42 @@ a.playerLink {
 	-webkit-touch-callout: none;
 	touch-action: pan-y;
 }
+
+/* ============================================
+   Game tabs — overrides paper-kit nav styles
+   ============================================ */
+ul#gameTab.nav-tabs {
+	border-bottom: 2px solid #ddd;
+	margin-bottom: 16px;
+	padding-left: 0;
+}
+
+ul#gameTab.nav-tabs > li > a {
+	color: #888;
+	border-radius: 4px 4px 0 0;
+	border: 1px solid transparent;
+	font-weight: 600;
+	font-size: 13px;
+	letter-spacing: 0.5px;
+	text-transform: uppercase;
+	padding: 10px 20px;
+	background: transparent;
+	display: block;
+}
+
+ul#gameTab.nav-tabs > li > a:hover {
+	color: #444;
+	background: #f5f5f5;
+	border-color: #ddd #ddd transparent;
+	text-decoration: none;
+}
+
+ul#gameTab.nav-tabs > li.active > a,
+ul#gameTab.nav-tabs > li.active > a:hover,
+ul#gameTab.nav-tabs > li.active > a:focus {
+	color: #333;
+	background: white;
+	border: 1px solid #ddd;
+	border-bottom-color: white;
+	margin-bottom: -2px;
+}

--- a/pages/boxscore/boxscore.css
+++ b/pages/boxscore/boxscore.css
@@ -429,8 +429,8 @@ ul#gameTab.nav-tabs > li.active > a:focus {
 }
 
 .pbp-table thead th {
-	padding: 10px 14px;
-	font-size: 10px;
+	padding: 8px 12px;
+	font-size: 9px;
 	font-weight: 700;
 	letter-spacing: 1.5px;
 	text-transform: uppercase;
@@ -447,39 +447,50 @@ ul#gameTab.nav-tabs > li.active > a:focus {
 }
 
 .pbp-table tbody td {
-	padding: 12px 14px;
+	padding: 8px 12px;
 	vertical-align: middle;
 	border: none;
 }
 
-.pbp-period {
-	font-size: 11px;
+/* Half section divider */
+.pbp-half-header td {
+	background: #f4f4f4;
+	font-size: 10px;
 	font-weight: 800;
-	color: #999;
-	letter-spacing: 0.5px;
-	white-space: nowrap;
+	letter-spacing: 2px;
+	text-transform: uppercase;
+	color: #777;
+	padding: 5px 12px;
+	border-top: 2px solid #e0e0e0;
+	border-bottom: 1px solid #e0e0e0;
+}
+
+.pbp-half-header:first-child td {
+	border-top: none;
 }
 
 .pbp-team {
-	font-size: 12px;
-	color: #666;
+	font-size: 11px;
+	color: #777;
 	font-weight: 600;
+	white-space: nowrap;
 }
 
 .pbp-player {
-	font-size: 13px;
+	font-size: 12px;
 	font-weight: 700;
 	color: #111;
 }
 
 .pbp-badge {
 	display: inline-block;
-	padding: 3px 9px;
-	border-radius: 4px;
-	font-size: 10px;
+	padding: 2px 7px;
+	border-radius: 3px;
+	font-size: 9px;
 	font-weight: 800;
 	letter-spacing: 1px;
 	text-transform: uppercase;
+	white-space: nowrap;
 }
 
 .pbp-badge-2pt {
@@ -498,12 +509,28 @@ ul#gameTab.nav-tabs > li.active > a:focus {
 }
 
 .pbp-score {
-	font-size: 14px;
+	font-size: 12px;
 	font-weight: 800;
 	color: #111;
 	white-space: nowrap;
 	text-align: right;
 	letter-spacing: -0.5px;
+}
+
+@media only screen and (max-width: 480px) {
+	.pbp-table thead th,
+	.pbp-table tbody td {
+		padding: 7px 8px;
+	}
+	.pbp-team {
+		font-size: 10px;
+	}
+	.pbp-player {
+		font-size: 11px;
+	}
+	.pbp-score {
+		font-size: 11px;
+	}
 }
 
 .pbp-legend {

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -9,6 +9,25 @@ CREATE TABLE IF NOT EXISTS app_events (
   created_at DATETIME NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS game_plays (
+  playID                  INT AUTO_INCREMENT PRIMARY KEY,
+  scheduleID              INT NOT NULL,
+  playerID                INT NOT NULL,
+  teamID                  INT NOT NULL,
+  stat_type               VARCHAR(20) NOT NULL,
+  points_scored           TINYINT DEFAULT 0,
+  home_score              SMALLINT DEFAULT 0,
+  away_score              SMALLINT DEFAULT 0,
+  period                  TINYINT DEFAULT 1,
+  clock_remaining_seconds INT DEFAULT NULL,
+  local_play_id           VARCHAR(60) NOT NULL,
+  is_removed              TINYINT(1) DEFAULT 0,
+  created_at              TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_local_play (scheduleID, local_play_id),
+  INDEX idx_schedule      (scheduleID),
+  INDEX idx_scoring       (scheduleID, points_scored, is_removed)
+);
+
 CREATE TABLE IF NOT EXISTS awards (
   AwardID       INT AUTO_INCREMENT PRIMARY KEY,
   AwardName     VARCHAR(200) DEFAULT NULL,


### PR DESCRIPTION
## Summary
- **New `game_plays` table** — stores every stat click in real-time (scheduleID, playerID, teamID, stat type, points scored, score context, period, undo tracking)
- **StatsApp.js** — fire-and-forget AJAX (`persistPlay` / `persistRemovePlay`) on each stat button click and undo; zero UX impact on statkeepers, all failures silent
- **New `StatsApp-LogPlay.cfm` endpoint** — handles `add` (INSERT IGNORE) and `remove` (UPDATE is_removed=1) actions
- **Box score tabs** — "Box Score" / "Play-By-Play" with modern underline-style tabs; custom vanilla JS switcher bypasses paper-kit interference
- **Play-By-Play tab** — ESPN-style dark header, colored play badges (2PT/3PT/FT), bold score; shows scoring plays only in reverse chronological order
- **Smart default tab** — defaults to Play-By-Play when no box score exists yet (game still in progress)
- **Async AI recap** — `cfthread` fires the OpenAI call in the background so StatsApp-Save redirects immediately instead of blocking 5–15s
- **Auto cache-busting** — `boxscore.css` version derived from file mod time, no more manual `?v=` bumps

## Test plan
- [ ] Enter stats in StatsApp during a live game — confirm rows appear in `game_plays` table in real-time
- [ ] Click "Remove" on a play in the log panel — confirm `is_removed = 1` in DB
- [ ] Open box score for a game in progress — confirm Play-By-Play tab is the default
- [ ] Open box score for a completed game — confirm Box Score tab is the default
- [ ] Click between tabs — confirm active underline indicator switches correctly
- [ ] Verify Play-By-Play shows scoring plays only (2PT/3PT/FT badges) in reverse order
- [ ] Submit StatsApp — confirm redirect is near-instant; recap appears on box score within ~15s
- [ ] Open box score before recap is ready — confirm no error, just no "Show Recap" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JkjVP97JWBgo2o8VdVwCgo