### PR TITLE
Replace Google Form team registration with internal form + admin appr…

### DIFF
--- a/admin-dashboard/pages/teamsOverview/teamsOverview.cfm
+++ b/admin-dashboard/pages/teamsOverview/teamsOverview.cfm
@@ -19,9 +19,31 @@
 <!--- Pending Teams (from the public registration form) --->
 <cfquery name="getPendingTeams" datasource="roundleague">
 	SELECT pending_teamsID, teamName, selectedDivision, status, captainFirstName, captainLastName,
-	       allPlayersOver18, phoneNumber, highestLevel, playerCountEstimate, vaccinatedCount,
+	       allPlayersOver18, email, phoneNumber, highestLevel, playerCountEstimate,
 	       dayPreference, referralSource, referralOther, dateAdded
 	FROM pending_teams
+	WHERE status = 'Pending'
+	ORDER BY dateAdded DESC
+</cfquery>
+
+<!--- Inactive Teams (real teams marked Inactive via the status dropdown) --->
+<cfquery name="getInactiveTeams" datasource="roundleague">
+	SELECT teamID, t.STATUS, teamName, t.registerDate, p.firstName, p.lastName, d.DivisionName, s.SeasonName
+	FROM teams t
+	LEFT JOIN players p ON p.PlayerID = t.captainPlayerID
+	LEFT JOIN divisions d ON d.divisionID = t.DivisionID
+	LEFT JOIN seasons s ON s.seasonID = t.seasonID
+	WHERE t.status = 'Inactive'
+	ORDER BY teamName
+</cfquery>
+
+<!--- Rejected registrations (kept for later review, not deleted) --->
+<cfquery name="getRejectedTeams" datasource="roundleague">
+	SELECT pending_teamsID, teamName, selectedDivision, status, captainFirstName, captainLastName,
+	       allPlayersOver18, email, phoneNumber, highestLevel, playerCountEstimate,
+	       dayPreference, referralSource, referralOther, dateAdded
+	FROM pending_teams
+	WHERE status = 'Rejected'
 	ORDER BY dateAdded DESC
 </cfquery>
 
@@ -96,6 +118,14 @@
           </cfif>
         </a>
       </li>
+      <li class="nav-item">
+        <a class="nav-link" id="inactive-tab" data-toggle="tab" href="##inactiveTeamsPane" role="tab">
+          Inactive Teams
+          <cfif getRejectedTeams.recordCount GT 0>
+            <span class="badge badge-danger">#getRejectedTeams.recordCount#</span>
+          </cfif>
+        </a>
+      </li>
     </ul>
 
     <div class="tab-content">
@@ -146,10 +176,10 @@
               <th>League</th>
               <th>Captain</th>
               <th>Over 18?</th>
+              <th>Email</th>
               <th>Phone</th>
               <th>Experience</th>
               <th>Player Count</th>
-              <th>Vaccinated</th>
               <th>Day Preference</th>
               <th>Referral</th>
               <th>Date Submitted</th>
@@ -170,10 +200,10 @@
                 <td data-label="League">#getPendingTeams.selectedDivision#</td>
                 <td data-label="Captain">#getPendingTeams.captainFirstName# #getPendingTeams.captainLastName#</td>
                 <td data-label="Over 18?">#getPendingTeams.allPlayersOver18#</td>
+                <td data-label="Email">#getPendingTeams.email#</td>
                 <td data-label="Phone">#getPendingTeams.phoneNumber#</td>
                 <td data-label="Experience">#structKeyExists(experienceLabels, getPendingTeams.highestLevel) ? experienceLabels[getPendingTeams.highestLevel] : getPendingTeams.highestLevel#</td>
                 <td data-label="Player Count">#getPendingTeams.playerCountEstimate#</td>
-                <td data-label="Vaccinated">#getPendingTeams.vaccinatedCount#</td>
                 <td data-label="Day Preference">#getPendingTeams.dayPreference#</td>
                 <td data-label="Referral"><cfif getPendingTeams.referralSource EQ 'Other'>#getPendingTeams.referralOther#<cfelse>#getPendingTeams.referralSource#</cfif></td>
                 <td data-label="Date Submitted">#DateFormat(getPendingTeams.dateAdded, "mm/dd/yyyy")#</td>
@@ -184,9 +214,98 @@
                     data-team-name="#getPendingTeams.teamName#"
                     data-captain-first="#getPendingTeams.captainFirstName#"
                     data-captain-last="#getPendingTeams.captainLastName#"
-                    data-captain-phone="#getPendingTeams.phoneNumber#">Approve</button>
+                    data-captain-phone="#getPendingTeams.phoneNumber#"
+                    data-captain-email="#getPendingTeams.email#">Approve</button>
                   <button type="button" class="btn btn-sm btn-outline-secondary rejectBtn"
                     data-pending-id="#getPendingTeams.pending_teamsID#">Reject</button>
+                </td>
+              </tr>
+            </cfloop>
+          </tbody>
+        </table>
+      </div>
+
+      <!--- Inactive Teams Tab --->
+      <div class="tab-pane fade" id="inactiveTeamsPane" role="tabpanel">
+        <h5>Inactive Teams</h5>
+        <table id="inactiveTeamsTable" class="display" style="width:100%">
+          <thead>
+            <tr>
+              <th>Status</th>
+              <th>Team</th>
+              <th>Captain</th>
+              <th>Register Date</th>
+              <th>Current Division</th>
+              <th>Current Season</th>
+            </tr>
+          </thead>
+          <tbody>
+            <cfloop query="getInactiveTeams">
+              <tr>
+                <td data-label="Status">
+                  <select name="status" class="statusSelect" data-value="#getInactiveTeams.teamID#">
+                    <option value=""></option>
+                    <option value="Active" <cfif getInactiveTeams.status EQ 'Active'>selected</cfif>>Active</option>
+                    <option value="Inactive" <cfif getInactiveTeams.status EQ 'Inactive'>selected</cfif>>Inactive</option>
+                  </select>
+                </td>
+                <td data-label="Team">#getInactiveTeams.teamname#</td>
+                <td data-label="Captain">#getInactiveTeams.firstName# #getInactiveTeams.lastName#</td>
+                <td data-label="Register Date">#DateFormat(getInactiveTeams.RegisterDate, "mm/dd/yyyy")#</td>
+                <td data-label="Current Division">#getInactiveTeams.divisionName#</td>
+                <td data-label="Current Season">#getInactiveTeams.seasonName#</td>
+              </tr>
+            </cfloop>
+          </tbody>
+        </table>
+
+        <hr>
+
+        <h5>Rejected Registrations</h5>
+        <table id="rejectedTeamsTable" class="display" style="width:100%">
+          <thead>
+            <tr>
+              <th>Team</th>
+              <th>League</th>
+              <th>Captain</th>
+              <th>Over 18?</th>
+              <th>Email</th>
+              <th>Phone</th>
+              <th>Experience</th>
+              <th>Player Count</th>
+              <th>Day Preference</th>
+              <th>Referral</th>
+              <th>Date Submitted</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <cfloop query="getRejectedTeams">
+              <tr>
+                <td data-label="Team">#getRejectedTeams.teamName#</td>
+                <td data-label="League">#getRejectedTeams.selectedDivision#</td>
+                <td data-label="Captain">#getRejectedTeams.captainFirstName# #getRejectedTeams.captainLastName#</td>
+                <td data-label="Over 18?">#getRejectedTeams.allPlayersOver18#</td>
+                <td data-label="Email">#getRejectedTeams.email#</td>
+                <td data-label="Phone">#getRejectedTeams.phoneNumber#</td>
+                <td data-label="Experience">#structKeyExists(experienceLabels, getRejectedTeams.highestLevel) ? experienceLabels[getRejectedTeams.highestLevel] : getRejectedTeams.highestLevel#</td>
+                <td data-label="Player Count">#getRejectedTeams.playerCountEstimate#</td>
+                <td data-label="Day Preference">#getRejectedTeams.dayPreference#</td>
+                <td data-label="Referral"><cfif getRejectedTeams.referralSource EQ 'Other'>#getRejectedTeams.referralOther#<cfelse>#getRejectedTeams.referralSource#</cfif></td>
+                <td data-label="Date Submitted">#DateFormat(getRejectedTeams.dateAdded, "mm/dd/yyyy")#</td>
+                <td data-label="Actions">
+                  <button type="button" class="btn btn-sm btn-outline-danger approveBtn"
+                    data-toggle="modal" data-target="##approveTeamModal"
+                    data-pending-id="#getRejectedTeams.pending_teamsID#"
+                    data-team-name="#getRejectedTeams.teamName#"
+                    data-captain-first="#getRejectedTeams.captainFirstName#"
+                    data-captain-last="#getRejectedTeams.captainLastName#"
+                    data-captain-phone="#getRejectedTeams.phoneNumber#"
+                    data-captain-email="#getRejectedTeams.email#">Approve</button>
+                  <button type="button" class="btn btn-sm btn-outline-secondary restoreBtn"
+                    data-pending-id="#getRejectedTeams.pending_teamsID#">Restore to Pending</button>
+                  <button type="button" class="btn btn-sm btn-outline-secondary deletePermanentlyBtn"
+                    data-pending-id="#getRejectedTeams.pending_teamsID#">Delete Permanently</button>
                 </td>
               </tr>
             </cfloop>

--- a/admin-dashboard/pages/teamsOverview/teamsOverview.cfm
+++ b/admin-dashboard/pages/teamsOverview/teamsOverview.cfm
@@ -1,18 +1,82 @@
 
 <cfinclude template="/admin-dashboard/admin_header.cfm">
 <!--- Page Specific CSS/JS Here --->
+<link href="teamsOverview.css?v=1.0" rel="stylesheet">
 
 <cfoutput>
 
-<!--- CFQuery --->
+<!--- Active Teams --->
 <cfquery name="getTeam" datasource="roundleague">
 	SELECT teamID, t.STATUS, teamName, t.registerDate, p.firstName, p.lastName, d.DivisionName, s.SeasonName
 	FROM teams t
 	LEFT JOIN players p ON p.PlayerID = t.captainPlayerID
 	LEFT JOIN divisions d ON d.divisionID = t.DivisionID
-	LEFT JOIN seasons s ON s.seasonID = t.seasonID 
-	ORDER BY STATUS
+	LEFT JOIN seasons s ON s.seasonID = t.seasonID
+	WHERE t.status = 'Active'
+	ORDER BY teamName
 </cfquery>
+
+<!--- Pending Teams (from the public registration form) --->
+<cfquery name="getPendingTeams" datasource="roundleague">
+	SELECT pending_teamsID, teamName, selectedDivision, status, captainFirstName, captainLastName,
+	       allPlayersOver18, phoneNumber, highestLevel, playerCountEstimate, vaccinatedCount,
+	       dayPreference, referralSource, referralOther, dateAdded
+	FROM pending_teams
+	ORDER BY dateAdded DESC
+</cfquery>
+
+<!--- Divisions for the current season, for the Approve modal --->
+<cfquery name="getDivisions" datasource="roundleague">
+	SELECT DivisionID, DivisionName
+	FROM Divisions
+	WHERE SeasonID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#session.CurrentSeasonID#">
+</cfquery>
+
+<cfquery name="getCurrentSeason" datasource="roundleague">
+	SELECT SeasonID, SeasonName
+	FROM Seasons
+	WHERE SeasonID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#session.CurrentSeasonID#">
+</cfquery>
+
+<!--- Approve Pending Team Modal --->
+<div class="modal fade" id="approveTeamModal" tabindex="-1" role="dialog" aria-labelledby="approveTeamModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="approveTeamModalLabel">Approve Team</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">x</span>
+        </button>
+      </div>
+      <div class="modal-body">
+        <p>Approving <strong><span id="approveTeamName"></span></strong></p>
+        <div class="form-group">
+          <label>Season</label>
+          <p>#getCurrentSeason.SeasonName#</p>
+          <input type="hidden" id="approveSeasonID" value="#session.CurrentSeasonID#">
+        </div>
+        <div class="form-group">
+          <label>Assign Division</label>
+          <select id="approveDivisionSelect" class="form-control">
+            <option value="">-- Select Division --</option>
+            <cfloop query="getDivisions">
+              <option value="#getDivisions.DivisionID#">#getDivisions.DivisionName#</option>
+            </cfloop>
+          </select>
+        </div>
+        <div class="form-group">
+          <label>Captain may be an existing player</label>
+          <div id="captainMatchLoading">Checking for existing player records...</div>
+          <div id="captainMatchResults" style="display:none;"></div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default btn-link" data-dismiss="modal">Cancel</button>
+        <button type="button" class="btn btn-outline-danger btn-round" id="confirmApproveBtn">Approve</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <!-- End Navbar -->
 <div class="content">
@@ -20,7 +84,24 @@
   <div class="col-md-12">
     <h3 class="description">Teams Overview</h3>
 
-        <!--- Content Here --->
+    <ul class="nav nav-tabs" id="teamsOverviewTabs" role="tablist">
+      <li class="nav-item">
+        <a class="nav-link active" id="active-tab" data-toggle="tab" href="##activeTeamsPane" role="tab">Active Teams</a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" id="pending-tab" data-toggle="tab" href="##pendingTeamsPane" role="tab">
+          Pending Teams
+          <cfif getPendingTeams.recordCount GT 0>
+            <span class="badge badge-danger">#getPendingTeams.recordCount#</span>
+          </cfif>
+        </a>
+      </li>
+    </ul>
+
+    <div class="tab-content">
+
+      <!--- Active Teams Tab --->
+      <div class="tab-pane fade show active" id="activeTeamsPane" role="tabpanel">
         <form name="teamsOverviewForm" method="POST">
 		    <table id="teamsOverviewTable" class="display" style="width:100%">
 		            <thead>
@@ -40,7 +121,6 @@
 		            		<select name="status" class="statusSelect" data-value="#getTeam.teamID#">
 		            			<option value=""></option>
 		            			<option value="Active" <cfif getTeam.status EQ 'Active'>selected</cfif>>Active</option>
-		            			<option value="Pending" <cfif getTeam.status EQ 'Pending'>selected</cfif>>Pending</option>
 		            			<option value="Inactive" <cfif getTeam.status EQ 'Inactive'>selected</cfif>>Inactive</option>
 		            		</select>
 		                  </td>
@@ -55,6 +135,66 @@
 		    </table>
 		    <a href="addTeam.cfm"><input type="button" class="btn btn-outline-danger btn-round addTeam" value="Add Team" name="addTeam"></a>
 		</form>
+      </div>
+
+      <!--- Pending Teams Tab --->
+      <div class="tab-pane fade" id="pendingTeamsPane" role="tabpanel">
+        <table id="pendingTeamsTable" class="display" style="width:100%">
+          <thead>
+            <tr>
+              <th>Team</th>
+              <th>League</th>
+              <th>Captain</th>
+              <th>Over 18?</th>
+              <th>Phone</th>
+              <th>Experience</th>
+              <th>Player Count</th>
+              <th>Vaccinated</th>
+              <th>Day Preference</th>
+              <th>Referral</th>
+              <th>Date Submitted</th>
+              <th>Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            <cfset experienceLabels = {
+              "1": "1 - Recreational",
+              "2": "2 - High School Varsity",
+              "3": "3 - College",
+              "4": "4 - D-1 University",
+              "5": "5 - Professional"
+            }>
+            <cfloop query="getPendingTeams">
+              <tr>
+                <td data-label="Team">#getPendingTeams.teamName#</td>
+                <td data-label="League">#getPendingTeams.selectedDivision#</td>
+                <td data-label="Captain">#getPendingTeams.captainFirstName# #getPendingTeams.captainLastName#</td>
+                <td data-label="Over 18?">#getPendingTeams.allPlayersOver18#</td>
+                <td data-label="Phone">#getPendingTeams.phoneNumber#</td>
+                <td data-label="Experience">#structKeyExists(experienceLabels, getPendingTeams.highestLevel) ? experienceLabels[getPendingTeams.highestLevel] : getPendingTeams.highestLevel#</td>
+                <td data-label="Player Count">#getPendingTeams.playerCountEstimate#</td>
+                <td data-label="Vaccinated">#getPendingTeams.vaccinatedCount#</td>
+                <td data-label="Day Preference">#getPendingTeams.dayPreference#</td>
+                <td data-label="Referral"><cfif getPendingTeams.referralSource EQ 'Other'>#getPendingTeams.referralOther#<cfelse>#getPendingTeams.referralSource#</cfif></td>
+                <td data-label="Date Submitted">#DateFormat(getPendingTeams.dateAdded, "mm/dd/yyyy")#</td>
+                <td data-label="Actions">
+                  <button type="button" class="btn btn-sm btn-outline-danger approveBtn"
+                    data-toggle="modal" data-target="##approveTeamModal"
+                    data-pending-id="#getPendingTeams.pending_teamsID#"
+                    data-team-name="#getPendingTeams.teamName#"
+                    data-captain-first="#getPendingTeams.captainFirstName#"
+                    data-captain-last="#getPendingTeams.captainLastName#"
+                    data-captain-phone="#getPendingTeams.phoneNumber#">Approve</button>
+                  <button type="button" class="btn btn-sm btn-outline-secondary rejectBtn"
+                    data-pending-id="#getPendingTeams.pending_teamsID#">Reject</button>
+                </td>
+              </tr>
+            </cfloop>
+          </tbody>
+        </table>
+      </div>
+
+    </div>
   </div>
 </div>
 </div>

--- a/admin-dashboard/pages/teamsOverview/teamsOverview.css
+++ b/admin-dashboard/pages/teamsOverview/teamsOverview.css
@@ -1,0 +1,21 @@
+#teamsOverviewTabs {
+  margin-bottom: 20px;
+}
+
+#teamsOverviewTabs .nav-link {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+#teamsOverviewTabs .badge {
+  margin-left: 6px;
+  vertical-align: middle;
+}
+
+#pendingTeamsTable td {
+  vertical-align: middle;
+}
+
+.approveBtn {
+  margin-right: 5px;
+}

--- a/admin-dashboard/pages/teamsOverview/teamsOverview.js
+++ b/admin-dashboard/pages/teamsOverview/teamsOverview.js
@@ -1,5 +1,12 @@
 $(document).ready(function () {
-  $("#teamsOverviewTable").DataTable();
+  var activeTable = $("#teamsOverviewTable").DataTable();
+  var pendingTable = $("#pendingTeamsTable").DataTable();
+
+  // DataTables mis-sizes columns when initialized inside a hidden Bootstrap tab pane
+  $('a[data-toggle="tab"]').on("shown.bs.tab", function () {
+    activeTable.columns.adjust();
+    pendingTable.columns.adjust();
+  });
 
   $(document).on("change", ".statusSelect", function () {
     console.log("Update Status");
@@ -25,6 +32,140 @@ $(document).ready(function () {
       error: function (xhr, status, err) {
         console.error("updateTeamStatus failed:", status, err);
         alert("Failed to update team status. Check the console for details.");
+      },
+    });
+  });
+
+  var currentPendingID = null;
+
+  function escapeHtml(value) {
+    return $("<div>").text(value == null ? "" : value).html();
+  }
+
+  function renderCaptainMatches(matches) {
+    $("#captainMatchLoading").hide();
+    var $results = $("#captainMatchResults");
+
+    var html = "";
+    var createNewOption =
+      '<label style="display:block; font-weight: normal;">' +
+      '<input type="radio" name="captainLinkChoice" value="" checked> ' +
+      "Create a new player record (no match / different person)</label>";
+
+    if (matches && matches.length) {
+      html +=
+        '<div style="overflow-x: auto; max-width: 100%;">' +
+        '<table class="table table-sm" style="font-size: 12px; margin-bottom: 0;"><thead><tr>' +
+        "<th></th><th>ID</th><th>Name</th><th>Email</th><th>Phone</th><th>Status</th><th>Team</th><th>Division</th>" +
+        "</tr></thead><tbody>";
+      matches.forEach(function (m) {
+        html +=
+          "<tr><td><input type=\"radio\" name=\"captainLinkChoice\" value=\"" +
+          escapeHtml(m.PlayerID) +
+          '"></td>' +
+          "<td>" + escapeHtml(m.PlayerID) + "</td>" +
+          "<td>" + escapeHtml(m.firstName) + " " + escapeHtml(m.lastName) + "</td>" +
+          "<td>" + escapeHtml(m.Email) + "</td>" +
+          "<td>" + escapeHtml(m.Phone) + "</td>" +
+          "<td>" + escapeHtml(m.Status) + "</td>" +
+          "<td>" + escapeHtml(m.Team) + "</td>" +
+          "<td>" + escapeHtml(m.DivisionName) + "</td></tr>";
+      });
+      html += "</tbody></table></div>";
+      html += '<div style="margin-top: 8px;">' + createNewOption + "</div>";
+    } else {
+      html += '<p class="text-muted">No matching players found.</p>';
+      html += createNewOption;
+    }
+
+    $results.html(html).show();
+  }
+
+  $(document).on("click", ".approveBtn", function () {
+    currentPendingID = $(this).data("pending-id");
+    $("#approveTeamName").text($(this).data("team-name"));
+    $("#approveDivisionSelect").val("");
+
+    $("#captainMatchResults").hide().empty();
+    $("#captainMatchLoading").show();
+
+    $.ajax({
+      type: "GET",
+      url: "/library/teams.cfc?method=searchDuplicateCaptains",
+      cache: false,
+      data: {
+        firstName: $(this).data("captain-first"),
+        lastName: $(this).data("captain-last"),
+        phone: $(this).data("captain-phone"),
+      },
+      success: function (data) {
+        renderCaptainMatches(Array.isArray(data) ? data : []);
+      },
+      error: function (xhr, status, err) {
+        console.error("searchDuplicateCaptains failed:", status, err);
+        renderCaptainMatches([]);
+      },
+    });
+  });
+
+  $("#confirmApproveBtn").on("click", function () {
+    var divisionID = $("#approveDivisionSelect").val();
+    if (!divisionID) {
+      alert("Please select a division before approving.");
+      return;
+    }
+
+    var linkPlayerID = $('input[name="captainLinkChoice"]:checked').val() || 0;
+
+    $.ajax({
+      type: "POST",
+      url: "/library/teams.cfc?method=approvePendingTeam",
+      cache: false,
+      data: {
+        pendingTeamID: currentPendingID,
+        divisionID: divisionID,
+        seasonID: $("#approveSeasonID").val(),
+        linkPlayerID: linkPlayerID,
+      },
+      success: function (data) {
+        if (data === "Success") {
+          location.reload();
+        } else {
+          alert("Approve failed: " + data);
+        }
+      },
+      error: function (xhr, status, err) {
+        console.error("approvePendingTeam failed:", status, err);
+        alert("Failed to approve team. Check the console for details.");
+      },
+    });
+
+    $("#approveTeamModal").modal("hide");
+  });
+
+  $(document).on("click", ".rejectBtn", function () {
+    var pendingTeamID = $(this).data("pending-id");
+    if (!confirm("Reject and delete this pending team registration?")) {
+      return;
+    }
+
+    $.ajax({
+      type: "POST",
+      url: "/library/teams.cfc?method=rejectPendingTeam",
+      cache: false,
+      data: {
+        pendingTeamID: pendingTeamID,
+      },
+      success: function (data) {
+        if (data === "Success") {
+          location.reload();
+        } else {
+          alert("Reject failed: " + data);
+        }
+      },
+      error: function (xhr, status, err) {
+        console.error("rejectPendingTeam failed:", status, err);
+        alert("Failed to reject team. Check the console for details.");
       },
     });
   });

--- a/admin-dashboard/pages/teamsOverview/teamsOverview.js
+++ b/admin-dashboard/pages/teamsOverview/teamsOverview.js
@@ -1,11 +1,15 @@
 $(document).ready(function () {
   var activeTable = $("#teamsOverviewTable").DataTable();
   var pendingTable = $("#pendingTeamsTable").DataTable();
+  var inactiveTable = $("#inactiveTeamsTable").DataTable();
+  var rejectedTable = $("#rejectedTeamsTable").DataTable();
 
   // DataTables mis-sizes columns when initialized inside a hidden Bootstrap tab pane
   $('a[data-toggle="tab"]').on("shown.bs.tab", function () {
     activeTable.columns.adjust();
     pendingTable.columns.adjust();
+    inactiveTable.columns.adjust();
+    rejectedTable.columns.adjust();
   });
 
   $(document).on("change", ".statusSelect", function () {
@@ -97,6 +101,7 @@ $(document).ready(function () {
         firstName: $(this).data("captain-first"),
         lastName: $(this).data("captain-last"),
         phone: $(this).data("captain-phone"),
+        email: $(this).data("captain-email"),
       },
       success: function (data) {
         renderCaptainMatches(Array.isArray(data) ? data : []);
@@ -145,7 +150,7 @@ $(document).ready(function () {
 
   $(document).on("click", ".rejectBtn", function () {
     var pendingTeamID = $(this).data("pending-id");
-    if (!confirm("Reject and delete this pending team registration?")) {
+    if (!confirm("Reject this registration? It will move to the Inactive tab for review.")) {
       return;
     }
 
@@ -166,6 +171,60 @@ $(document).ready(function () {
       error: function (xhr, status, err) {
         console.error("rejectPendingTeam failed:", status, err);
         alert("Failed to reject team. Check the console for details.");
+      },
+    });
+  });
+
+  $(document).on("click", ".restoreBtn", function () {
+    var pendingTeamID = $(this).data("pending-id");
+    if (!confirm("Restore this registration to Pending?")) {
+      return;
+    }
+
+    $.ajax({
+      type: "POST",
+      url: "/library/teams.cfc?method=restorePendingTeam",
+      cache: false,
+      data: {
+        pendingTeamID: pendingTeamID,
+      },
+      success: function (data) {
+        if (data === "Success") {
+          location.reload();
+        } else {
+          alert("Restore failed: " + data);
+        }
+      },
+      error: function (xhr, status, err) {
+        console.error("restorePendingTeam failed:", status, err);
+        alert("Failed to restore registration. Check the console for details.");
+      },
+    });
+  });
+
+  $(document).on("click", ".deletePermanentlyBtn", function () {
+    var pendingTeamID = $(this).data("pending-id");
+    if (!confirm("Permanently delete this registration? This cannot be undone.")) {
+      return;
+    }
+
+    $.ajax({
+      type: "POST",
+      url: "/library/teams.cfc?method=deletePendingTeam",
+      cache: false,
+      data: {
+        pendingTeamID: pendingTeamID,
+      },
+      success: function (data) {
+        if (data === "Success") {
+          location.reload();
+        } else {
+          alert("Delete failed: " + data);
+        }
+      },
+      error: function (xhr, status, err) {
+        console.error("deletePendingTeam failed:", status, err);
+        alert("Failed to delete registration. Check the console for details.");
       },
     });
   });

--- a/header.cfm
+++ b/header.cfm
@@ -106,7 +106,7 @@
             <ul class="dropdown-menu dropdown-info" aria-labelledby="dropdownMenuButton">
               <a class="dropdown-item" href="/pages/register/register.cfm">Register Player</a>
               <div class="dropdown-divider"></div>
-              <a class="dropdown-item" href="https://forms.gle/apAEaVGKYT3U9NUJ8" target="_blank">Register Team</a>
+              <a class="dropdown-item" href="/pages/RegisterTeam/registerTeam.cfm">Register Team</a>
             </ul>
           </div>
           <!--- <li class="nav-item">

--- a/library/teams.cfc
+++ b/library/teams.cfc
@@ -59,10 +59,11 @@
  </cffunction> 
 
   <cffunction name="searchDuplicateCaptains" returntype="any" access="remote" returnformat="json"
-	hint="Find existing players matching a pending team's captain by exact name or phone, for duplicate-detection at approval time">
+	hint="Find existing players matching a pending team's captain by exact name, phone, or email, for duplicate-detection at approval time">
 	<cfargument name="firstName" default="" required="yes" type="string">
 	<cfargument name="lastName" default="" required="yes" type="string">
 	<cfargument name="phone" default="" required="yes" type="string">
+	<cfargument name="email" default="" required="no" type="string">
 
 		<cfquery name="matches" datasource="roundleague">
 			SELECT p.PlayerID, p.firstName, p.lastName, p.Email, p.Phone, p.Status, p.Team,
@@ -76,6 +77,10 @@
 					AND LOWER(TRIM(p.lastName)) = LOWER(TRIM(<cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#lastName#">))
 				)
 				OR p.Phone = <cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#phone#">
+				OR (
+					LENGTH(TRIM(<cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#email#">)) > 0
+					AND LOWER(TRIM(p.Email)) = LOWER(TRIM(<cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#email#">))
+				)
 			)
 			ORDER BY p.PlayerID DESC
 		</cfquery>
@@ -124,6 +129,7 @@
 					<cfquery name="updateExistingCaptain" datasource="roundleague">
 						UPDATE players
 						SET Phone = <cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.phoneNumber#">,
+						    Email = <cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.email#">,
 						    Status = 'Active',
 						    DivisionID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#divisionID#">
 						WHERE PlayerID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#linkPlayerID#">
@@ -142,7 +148,7 @@
 						VALUES
 						(
 							<cfqueryparam cfsqltype="cf_sql_date" value="#DateFormat(now(), 'mm/dd/yyyy')#">,
-							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.email#">,
 							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.captainFirstName#">,
 							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.captainLastName#">,
 							<cfqueryparam cfsqltype="cf_sql_date" value="1900-01-01">,
@@ -196,7 +202,45 @@
  </cffunction>
 
  <cffunction name="rejectPendingTeam" returntype="any" access="remote" returnformat="json"
-	hint="Delete a pending team registration">
+	hint="Mark a pending team registration as Rejected (kept for later review, not deleted)">
+	<cfargument name="pendingTeamID" default="" required="yes" type="numeric">
+
+		<cftry>
+			<cfquery name="rejectPending" datasource="roundleague">
+				UPDATE pending_teams
+				SET status = 'Rejected'
+				WHERE pending_teamsID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#pendingTeamID#">
+			</cfquery>
+
+			<cfcatch>
+				<cfreturn cfcatch.message>
+			</cfcatch>
+		</cftry>
+
+		<cfreturn 'Success'>
+ </cffunction>
+
+ <cffunction name="restorePendingTeam" returntype="any" access="remote" returnformat="json"
+	hint="Move a rejected registration back to Pending">
+	<cfargument name="pendingTeamID" default="" required="yes" type="numeric">
+
+		<cftry>
+			<cfquery name="restorePending" datasource="roundleague">
+				UPDATE pending_teams
+				SET status = 'Pending'
+				WHERE pending_teamsID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#pendingTeamID#">
+			</cfquery>
+
+			<cfcatch>
+				<cfreturn cfcatch.message>
+			</cfcatch>
+		</cftry>
+
+		<cfreturn 'Success'>
+ </cffunction>
+
+ <cffunction name="deletePendingTeam" returntype="any" access="remote" returnformat="json"
+	hint="Permanently delete a pending team registration (e.g. a previously-rejected row the admin is done reviewing)">
 	<cfargument name="pendingTeamID" default="" required="yes" type="numeric">
 
 		<cftry>

--- a/library/teams.cfc
+++ b/library/teams.cfc
@@ -58,6 +58,161 @@
  		<cfreturn 'Success'>
  </cffunction> 
 
+  <cffunction name="searchDuplicateCaptains" returntype="any" access="remote" returnformat="json"
+	hint="Find existing players matching a pending team's captain by exact name or phone, for duplicate-detection at approval time">
+	<cfargument name="firstName" default="" required="yes" type="string">
+	<cfargument name="lastName" default="" required="yes" type="string">
+	<cfargument name="phone" default="" required="yes" type="string">
+
+		<cfquery name="matches" datasource="roundleague">
+			SELECT p.PlayerID, p.firstName, p.lastName, p.Email, p.Phone, p.Status, p.Team,
+			       IFNULL(d.DivisionName, 'N/A') AS DivisionName
+			FROM players p
+			LEFT JOIN divisions d ON d.DivisionID = p.DivisionID
+			WHERE p.mergedIntoPlayerID IS NULL
+			AND (
+				(
+					LOWER(TRIM(p.firstName)) = LOWER(TRIM(<cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#firstName#">))
+					AND LOWER(TRIM(p.lastName)) = LOWER(TRIM(<cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#lastName#">))
+				)
+				OR p.Phone = <cfqueryparam cfsqltype="CF_SQL_VARCHAR" value="#phone#">
+			)
+			ORDER BY p.PlayerID DESC
+		</cfquery>
+
+		<cfset results = []>
+		<cfloop query="matches">
+			<cfset arrayAppend(results, {
+				"PlayerID": matches.PlayerID,
+				"firstName": matches.firstName,
+				"lastName": matches.lastName,
+				"Email": matches.Email,
+				"Phone": matches.Phone,
+				"Status": matches.Status,
+				"Team": matches.Team,
+				"DivisionName": matches.DivisionName
+			})>
+		</cfloop>
+
+		<cfreturn results>
+ </cffunction>
+
+  <cffunction name="approvePendingTeam" returntype="any" access="remote" returnformat="json"
+	hint="Approve a pending team registration: create or link the captain as a player, create the team, and remove the pending record">
+	<cfargument name="pendingTeamID" default="" required="yes" type="numeric">
+	<cfargument name="divisionID" default="" required="yes" type="numeric">
+	<cfargument name="seasonID" default="" required="yes" type="numeric">
+	<cfargument name="linkPlayerID" default="0" required="no" type="numeric">
+
+		<cftry>
+			<cftransaction>
+
+				<cfquery name="getPending" datasource="roundleague">
+					SELECT * FROM pending_teams
+					WHERE pending_teamsID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#pendingTeamID#">
+				</cfquery>
+
+				<cfif getPending.recordCount EQ 0>
+					<cfreturn "Pending team not found.">
+				</cfif>
+
+				<cfif linkPlayerID GT 0>
+					<!--- Link to an existing player instead of creating a new one.
+					      Players must re-register each season per the site's own
+					      "returning player" notice, so refreshing these fields is
+					      expected rather than a data-loss risk. --->
+					<cfquery name="updateExistingCaptain" datasource="roundleague">
+						UPDATE players
+						SET Phone = <cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.phoneNumber#">,
+						    Status = 'Active',
+						    DivisionID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#divisionID#">
+						WHERE PlayerID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#linkPlayerID#">
+					</cfquery>
+					<cfset newPlayerID = linkPlayerID>
+				<cfelse>
+					<!--- Auto-create the captain as a player. BirthDate is NOT NULL with no
+					      real value collected on the registration form (only a team-wide
+					      over-18 yes/no), so a sentinel placeholder date is used. --->
+					<cfquery name="addCaptainPlayer" datasource="roundleague" result="playerInsertResult">
+						INSERT INTO players
+						(RegisterDate, Email, firstName, lastName, BirthDate, Phone,
+						 HighestLevel, FreeAgent, position, height, weight, hometown,
+						 School, PermissionToShare, Status, PhotoURL, Instagram,
+						 DivisionID, Team, MastersLeague, is_youth)
+						VALUES
+						(
+							<cfqueryparam cfsqltype="cf_sql_date" value="#DateFormat(now(), 'mm/dd/yyyy')#">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.captainFirstName#">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.captainLastName#">,
+							<cfqueryparam cfsqltype="cf_sql_date" value="1900-01-01">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.phoneNumber#">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.highestLevel#">,
+							'No',
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							'No',
+							'Active',
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="">,
+							<cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#divisionID#">,
+							<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.teamName#">,
+							'No',
+							0
+						)
+					</cfquery>
+					<cfset newPlayerID = playerInsertResult.GENERATEDKEY>
+				</cfif>
+
+				<cfquery name="addTeam" datasource="roundleague">
+					INSERT INTO Teams (Status, teamName, CaptainPlayerID, RegisterDate, DivisionID, SeasonID)
+					VALUES
+					(
+						<cfqueryparam cfsqltype="cf_sql_varchar" value="Active">,
+						<cfqueryparam cfsqltype="cf_sql_varchar" value="#getPending.teamName#">,
+						<cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#newPlayerID#">,
+						<cfqueryparam cfsqltype="cf_sql_date" value="#DateFormat(now(), 'mm/dd/yyyy')#">,
+						<cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#divisionID#">,
+						<cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#seasonID#">
+					)
+				</cfquery>
+
+				<cfquery name="deletePending" datasource="roundleague">
+					DELETE FROM pending_teams
+					WHERE pending_teamsID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#pendingTeamID#">
+				</cfquery>
+
+			</cftransaction>
+
+			<cfcatch>
+				<cfreturn cfcatch.message>
+			</cfcatch>
+		</cftry>
+
+		<cfreturn 'Success'>
+ </cffunction>
+
+ <cffunction name="rejectPendingTeam" returntype="any" access="remote" returnformat="json"
+	hint="Delete a pending team registration">
+	<cfargument name="pendingTeamID" default="" required="yes" type="numeric">
+
+		<cftry>
+			<cfquery name="deletePending" datasource="roundleague">
+				DELETE FROM pending_teams
+				WHERE pending_teamsID = <cfqueryparam cfsqltype="CF_SQL_INTEGER" value="#pendingTeamID#">
+			</cfquery>
+
+			<cfcatch>
+				<cfreturn cfcatch.message>
+			</cfcatch>
+		</cftry>
+
+		<cfreturn 'Success'>
+ </cffunction>
+
   <cffunction name="getTeamNameByTeamID"
 	hint="Get team name by teamID" returntype="string">
 	<cfargument name="teamID" default="" required="yes" type="numeric">

--- a/pages/RegisterTeam/registerTeam-save.cfm
+++ b/pages/RegisterTeam/registerTeam-save.cfm
@@ -1,6 +1,6 @@
 <cfparam name="form.dayPreference" default="">
-<cfparam name="form.vaccinatedCount" default="">
 <cfparam name="form.referralOther" default="">
+<cfparam name="form.email" default="">
 
 <!--- Required-field validation. Every field checked here maps to a NOT NULL
       column with no usable default, so a missing value must never reach the
@@ -11,11 +11,12 @@
 <cfif len(trim(form.allPlayersOver18)) EQ 0><cfset arrayAppend(local.missingFields, "Over 18 confirmation")></cfif>
 <cfif len(trim(form.captainName)) EQ 0><cfset arrayAppend(local.missingFields, "Captain Name")></cfif>
 <cfif len(trim(form.phoneNumber)) EQ 0><cfset arrayAppend(local.missingFields, "Phone Number")></cfif>
+<cfset local.cleanEmail = lCase(trim(form.email))>
+<cfif NOT reFind("^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{2,}$", local.cleanEmail) OR len(local.cleanEmail) GT 100>
+  <cfset arrayAppend(local.missingFields, "Email (valid address, under 100 characters)")>
+</cfif>
 <cfif len(trim(form.playerCountEstimate)) EQ 0><cfset arrayAppend(local.missingFields, "Player Count")></cfif>
 <cfif len(trim(form.highestLevel)) EQ 0><cfset arrayAppend(local.missingFields, "Level of Experience")></cfif>
-<cfif NOT len(trim(form.vaccinatedCount)) OR NOT isNumeric(form.vaccinatedCount) OR form.vaccinatedCount LT 0 OR form.vaccinatedCount GT 12>
-  <cfset arrayAppend(local.missingFields, "Number of Players Fully Vaccinated (0-12)")>
-</cfif>
 <cfif len(trim(form.referralSource)) EQ 0><cfset arrayAppend(local.missingFields, "How you heard about us")></cfif>
 
 <cfif len(trim(form.teamName)) GT 200 OR len(trim(form.captainName)) GT 200>
@@ -40,6 +41,7 @@
 <cfif reFind(local.suspiciousPattern, form.teamName)
       OR reFind(local.suspiciousPattern, form.captainName)
       OR reFind(local.suspiciousPattern, form.phoneNumber)
+      OR reFind(local.suspiciousPattern, form.email)
       OR reFind(local.suspiciousPattern, form.referralOther)>
   <cflog file="register_security" type="warning"
          text="Suspicious team registration payload rejected from #cgi.remote_addr# teamName=#htmlEditFormat(form.teamName)#">
@@ -64,8 +66,8 @@
   INSERT INTO pending_teams
   (
     teamName, selectedDivision, status, captainFirstName, captainLastName,
-    allPlayersOver18, phoneNumber, highestLevel, playerCountEstimate,
-    vaccinatedCount, dayPreference, referralSource, referralOther, dateAdded
+    allPlayersOver18, email, phoneNumber, highestLevel, playerCountEstimate,
+    dayPreference, referralSource, referralOther, dateAdded
   )
   VALUES
   (
@@ -75,10 +77,10 @@
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#local.captainFirstName#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#local.captainLastName#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.allPlayersOver18#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#local.cleanEmail#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.phoneNumber#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.highestLevel#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.playerCountEstimate#">,
-    <cfqueryparam cfsqltype="cf_sql_integer" value="#form.vaccinatedCount#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.dayPreference#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.referralSource#">,
     <cfqueryparam cfsqltype="cf_sql_varchar" value="#local.referralOtherValue#">,

--- a/pages/RegisterTeam/registerTeam-save.cfm
+++ b/pages/RegisterTeam/registerTeam-save.cfm
@@ -1,0 +1,106 @@
+<cfparam name="form.dayPreference" default="">
+<cfparam name="form.vaccinatedCount" default="">
+<cfparam name="form.referralOther" default="">
+
+<!--- Required-field validation. Every field checked here maps to a NOT NULL
+      column with no usable default, so a missing value must never reach the
+      INSERT below (send the user back to the form instead of crashing). --->
+<cfset local.missingFields = []>
+<cfif len(trim(form.teamName)) EQ 0><cfset arrayAppend(local.missingFields, "Team Name")></cfif>
+<cfif len(trim(form.selectedDivision)) EQ 0><cfset arrayAppend(local.missingFields, "League")></cfif>
+<cfif len(trim(form.allPlayersOver18)) EQ 0><cfset arrayAppend(local.missingFields, "Over 18 confirmation")></cfif>
+<cfif len(trim(form.captainName)) EQ 0><cfset arrayAppend(local.missingFields, "Captain Name")></cfif>
+<cfif len(trim(form.phoneNumber)) EQ 0><cfset arrayAppend(local.missingFields, "Phone Number")></cfif>
+<cfif len(trim(form.playerCountEstimate)) EQ 0><cfset arrayAppend(local.missingFields, "Player Count")></cfif>
+<cfif len(trim(form.highestLevel)) EQ 0><cfset arrayAppend(local.missingFields, "Level of Experience")></cfif>
+<cfif NOT len(trim(form.vaccinatedCount)) OR NOT isNumeric(form.vaccinatedCount) OR form.vaccinatedCount LT 0 OR form.vaccinatedCount GT 12>
+  <cfset arrayAppend(local.missingFields, "Number of Players Fully Vaccinated (0-12)")>
+</cfif>
+<cfif len(trim(form.referralSource)) EQ 0><cfset arrayAppend(local.missingFields, "How you heard about us")></cfif>
+
+<cfif len(trim(form.teamName)) GT 200 OR len(trim(form.captainName)) GT 200>
+  <cfthrow message="Team name and captain name must be under 200 characters.">
+</cfif>
+
+<cfif arrayLen(local.missingFields)>
+  <cfoutput>
+  <div class="main" style="background-color: white; margin-top: 50px;">
+    <div class="section text-center">
+      <div class="container">
+        <p class="toastMessage" style="color: red;">Please go back and fill out all required fields: #arrayToList(local.missingFields, ", ")#</p>
+        <a href="/pages/RegisterTeam/registerTeam.cfm" class="btn btn-primary btn-round mt-3">Back to Registration Form</a>
+      </div>
+    </div>
+  </div>
+  </cfoutput>
+  <cfexit>
+</cfif>
+
+<cfset local.suspiciousPattern = "(?i)(pg_sleep|waitfor\s+delay|dbms_pipe|union\s+select|sleep\s*\()">
+<cfif reFind(local.suspiciousPattern, form.teamName)
+      OR reFind(local.suspiciousPattern, form.captainName)
+      OR reFind(local.suspiciousPattern, form.phoneNumber)
+      OR reFind(local.suspiciousPattern, form.referralOther)>
+  <cflog file="register_security" type="warning"
+         text="Suspicious team registration payload rejected from #cgi.remote_addr# teamName=#htmlEditFormat(form.teamName)#">
+  <cfthrow message="Invalid characters in submitted fields.">
+</cfif>
+
+<!--- Split captain name into first/last (first word / remainder) --->
+<cfset local.cleanCaptainName = trim(form.captainName)>
+<cfset local.firstSpacePos = find(" ", local.cleanCaptainName)>
+<cfif local.firstSpacePos>
+  <cfset local.captainFirstName = left(local.cleanCaptainName, local.firstSpacePos - 1)>
+  <cfset local.captainLastName = trim(mid(local.cleanCaptainName, local.firstSpacePos + 1, len(local.cleanCaptainName)))>
+<cfelse>
+  <cfset local.captainFirstName = local.cleanCaptainName>
+  <cfset local.captainLastName = "">
+</cfif>
+
+<!--- "Other" free-text only applies when Other was actually selected --->
+<cfset local.referralOtherValue = (form.referralSource EQ "Other") ? form.referralOther : "">
+
+<cfquery name="addPendingTeam" datasource="roundleague">
+  INSERT INTO pending_teams
+  (
+    teamName, selectedDivision, status, captainFirstName, captainLastName,
+    allPlayersOver18, phoneNumber, highestLevel, playerCountEstimate,
+    vaccinatedCount, dayPreference, referralSource, referralOther, dateAdded
+  )
+  VALUES
+  (
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.teamName#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.selectedDivision#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="Pending">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#local.captainFirstName#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#local.captainLastName#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.allPlayersOver18#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.phoneNumber#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.highestLevel#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.playerCountEstimate#">,
+    <cfqueryparam cfsqltype="cf_sql_integer" value="#form.vaccinatedCount#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.dayPreference#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#form.referralSource#">,
+    <cfqueryparam cfsqltype="cf_sql_varchar" value="#local.referralOtherValue#">,
+    <cfqueryparam cfsqltype="cf_sql_date" value="#DateFormat(now(), 'mm/dd/yyyy')#">
+  )
+</cfquery>
+
+<cflog file="register_security" type="information"
+       text="New team registration submitted: teamName=#htmlEditFormat(form.teamName)# IP=#cgi.remote_addr#">
+
+<cfset toastMessage = "Thank you! Your team registration has been submitted and is pending review. We'll follow up with you shortly.">
+
+<cfoutput>
+<div class="main" style="background-color: white; margin-top: 50px;">
+	<div class="section text-center">
+	  <div class="container">
+
+		<!--- Content Here --->
+		<p class="toastMessage">#toastMessage#</p>
+		<a href="/" class="btn btn-primary btn-round mt-3">Return to Home</a>
+
+	  </div>
+	</div>
+</div>
+</cfoutput>

--- a/pages/RegisterTeam/registerTeam.cfm
+++ b/pages/RegisterTeam/registerTeam.cfm
@@ -78,6 +78,11 @@
 		                <input type="tel" required id="teamPhoneField" class="form-control border-input" name="phoneNumber" placeholder="123-456-7890">
 		              </div>
 
+		              <div class="form-group">
+		                <label>Team Manager's Email</label>
+		                <input type="email" required class="form-control border-input" name="email" placeholder="Email">
+		              </div>
+
 		              <div class="row">
 			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
 			              		<label class="biggerLabel">Player Count</label>
@@ -126,11 +131,6 @@
 			              		  </label>
 			              		</div>
 			              </div>
-		              </div>
-
-		              <div class="form-group">
-		                <label>Number of Players Fully Vaccinated</label>
-		                <input type="number" min="0" max="12" required class="form-control border-input" placeholder="0" name="vaccinatedCount">
 		              </div>
 
 		              <div class="row">

--- a/pages/RegisterTeam/registerTeam.cfm
+++ b/pages/RegisterTeam/registerTeam.cfm
@@ -1,0 +1,203 @@
+<cfinclude template="/header.cfm">
+
+<!--- Page Specific CSS/JS Here --->
+<link href="https://demos.creative-tim.com/paper-kit-2-pro/assets/css/paper-kit.min.css?v=2.3.1" rel="stylesheet">
+<cfoutput><link href="../RegisterTeam/registerTeam.css?v=#DateDiff('s', CreateDate(1970,1,1), Now())#" rel="stylesheet"></cfoutput>
+
+<cfoutput>
+
+<cfset leagueOptions = "Men's League,Women's League,Master's 40+ League">
+<cfset playerCountOptions = "I have 8-10 Players,I will need players from Free Agency">
+<cfset dayOptions = "Monday,Tuesday,Wednesday,Thursday,Friday,Saturday,Sunday">
+
+<cfif isDefined("form.registerTeamSubmit")>
+	<cfinclude template="registerTeam-save.cfm">
+	<cfexit>
+</cfif>
+
+<div class="main" style="background-color: white;">
+    <div class="section text-center">
+      <div class="container">
+
+        <!--- Content Here --->
+		<div class="wrapper">
+		    <div class="profile-content section" style="padding-top: 20px">
+		      <div class="container" style="padding-bottom: 20px">
+		      </div>
+
+		      <div class="container">
+		        <div class="row">
+		          <div class="col-md-6 ml-auto mr-auto">
+		            <h3 class="description">Register Your Team</h3>
+		            <form class="settings-form" method="POST">
+
+		              <div class="form-group">
+		                <label>Team Name</label>
+		                <input type="text" required class="form-control border-input" placeholder="Team Name" name="teamName">
+		              </div>
+
+		              <div class="row">
+			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
+			              		<label class="biggerLabel">Which League are you Interested in Joining?</label>
+			              		<cfloop list="#leagueOptions#" index="i" item="x">
+						            <div class="form-check-radio">
+						              <label class="form-check-label">
+						                <input class="form-check-input" type="radio" required name="selectedDivision" value="#x#"> #x#
+						                <span class="form-check-sign"></span>
+						              </label>
+						            </div>
+					        	</cfloop>
+			              		</div>
+		              </div>
+
+		              <div class="row">
+			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
+			              		<label class="biggerLabel">Is everyone on your team over 18?</label>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input" type="radio" required name="allPlayersOver18" value="Yes"> Yes
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input" type="radio" required name="allPlayersOver18" value="No"> No
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              </div>
+		              </div>
+
+		              <div class="form-group">
+		                <label>Team Captain/Manager's Name</label>
+		                <input type="text" required class="form-control border-input" placeholder="Captain/Manager's Name" name="captainName">
+		              </div>
+
+		              <div class="form-group">
+		                <label>Team Manager's Phone Number</label>
+		                <input type="tel" required id="teamPhoneField" class="form-control border-input" name="phoneNumber" placeholder="123-456-7890">
+		              </div>
+
+		              <div class="row">
+			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
+			              		<label class="biggerLabel">Player Count</label>
+			              		<cfloop list="#playerCountOptions#" index="i" item="x">
+						            <div class="form-check-radio">
+						              <label class="form-check-label">
+						                <input class="form-check-input" type="radio" required name="playerCountEstimate" value="#x#"> #x#
+						                <span class="form-check-sign"></span>
+						              </label>
+						            </div>
+					        	</cfloop>
+			              </div>
+		              </div>
+
+		              <div class="row">
+			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
+			              		<label class="biggerLabel">Team's Overall Level of Experience</label>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="1"> 1 - Recreational
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="2"> 2 - High School Varsity
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="3"> 3 - College
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="4"> 4 - D-1 University
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="5"> 5 - Professional
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              </div>
+		              </div>
+
+		              <div class="form-group">
+		                <label>Number of Players Fully Vaccinated</label>
+		                <input type="number" min="0" max="12" required class="form-control border-input" placeholder="0" name="vaccinatedCount">
+		              </div>
+
+		              <div class="row">
+			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
+			              		<label class="biggerLabel">Preference for League Days</label>
+			              		<cfloop list="#dayOptions#" index="i" item="x">
+						            <div class="form-check">
+						              <label class="form-check-label">
+						                <input class="form-check-input" type="checkbox" name="dayPreference" value="#x#"> #x#
+						                <span class="form-check-sign"></span>
+						              </label>
+						            </div>
+					        	</cfloop>
+			              </div>
+		              </div>
+
+		              <div class="row">
+			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
+			              		<label class="biggerLabel">How did you hear about us?</label>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Friends"> Friends
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Instagram"> Instagram
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Website"> Website
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-check-radio">
+			              		  <label class="form-check-label">
+			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Other"> Other
+			              		    <span class="form-check-sign"></span>
+			              		  </label>
+			              		</div>
+			              		<div class="form-group" id="referralOtherItem" style="display:none;">
+			              		  <input type="text" class="form-control border-input" placeholder="Please specify" name="referralOther" id="referralOtherInput">
+			              		</div>
+			              </div>
+		              </div>
+
+		              <input type="hidden" name="registerTeamSubmit" value="1">
+
+		              <div class="text-center errorDiv">
+		                <span class="errorMessage"></span>
+		              </div>
+		              <div class="text-center">
+		                <button type="submit" class="btn btn-wd btn-info btn-round saveBtn">Submit Registration</button>
+		              </div>
+		            </form>
+		          </div>
+		        </div>
+		      </div>
+		    </div>
+		  </div>
+	  </div>
+	</div>
+</div>
+</cfoutput>
+
+<cfinclude template="/footer.cfm">
+<cfoutput><script src="../RegisterTeam/registerTeam.js?v=#DateDiff('s', CreateDate(1970,1,1), Now())#"></script></cfoutput>

--- a/pages/RegisterTeam/registerTeam.css
+++ b/pages/RegisterTeam/registerTeam.css
@@ -1,0 +1,25 @@
+.nonTextQuestions {
+  padding: 10px;
+}
+
+h3.description {
+  color: #333;
+}
+
+.biggerLabel {
+  font-size: large;
+}
+
+.errorDiv {
+  padding: 20px;
+  font-weight: bold;
+  color: red;
+}
+
+.toastMessage {
+  font-weight: bold;
+}
+
+label {
+  font-weight: 600;
+}

--- a/pages/RegisterTeam/registerTeam.js
+++ b/pages/RegisterTeam/registerTeam.js
@@ -1,0 +1,32 @@
+$(document).ready(function () {
+	$('#teamPhoneField').keyup(function () {
+		$(this).val($(this).val().replace(/(\d{3})\-?(\d{3})\-?(\d{4})/, '$1-$2-$3'));
+	});
+
+	$('.referralRadio').on('change', function () {
+		if ($(this).val() === 'Other' && $(this).is(':checked')) {
+			$('#referralOtherItem').show();
+		} else {
+			$('#referralOtherItem').hide();
+			$('#referralOtherInput').val('');
+		}
+	});
+
+	$('.saveBtn').closest('form').on('submit', function () {
+		var missing = [];
+
+		if (!$('input[name="selectedDivision"]:checked').length) missing.push('League');
+		if (!$('input[name="allPlayersOver18"]:checked').length) missing.push('Over 18 confirmation');
+		if (!$('input[name="playerCountEstimate"]:checked').length) missing.push('Player Count');
+		if (!$('input[name="highestLevel"]:checked').length) missing.push('Level of Experience');
+		if (!$('input[name="referralSource"]:checked').length) missing.push('How you heard about us');
+
+		if (missing.length) {
+			$('.errorMessage').text('Please fill out all required fields: ' + missing.join(', '));
+			return false;
+		}
+
+		$('.errorMessage').text('');
+		return true;
+	});
+});

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -110,7 +110,6 @@ CREATE TABLE IF NOT EXISTS pending_teams (
   phoneNumber         VARCHAR(100) NOT NULL DEFAULT '0',
   highestLevel        VARCHAR(100) NOT NULL DEFAULT '0',
   playerCountEstimate VARCHAR(100) NOT NULL DEFAULT '0',
-  vaccinatedCount     INT NOT NULL DEFAULT 0,
   dayPreference       VARCHAR(100) NOT NULL DEFAULT '',
   referralSource      VARCHAR(50) NOT NULL DEFAULT '',
   referralOther       VARCHAR(255) NOT NULL DEFAULT '',

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -105,11 +105,15 @@ CREATE TABLE IF NOT EXISTS pending_teams (
   status              VARCHAR(25) NOT NULL DEFAULT '0',
   captainFirstName    VARCHAR(100) NOT NULL,
   captainLastName     VARCHAR(100) NOT NULL,
-  age                 INT NOT NULL DEFAULT 0,
+  allPlayersOver18    VARCHAR(3) NOT NULL DEFAULT '',
   email               VARCHAR(100) NOT NULL DEFAULT '0',
   phoneNumber         VARCHAR(100) NOT NULL DEFAULT '0',
   highestLevel        VARCHAR(100) NOT NULL DEFAULT '0',
-  playerCountEstimate INT NOT NULL DEFAULT 0,
+  playerCountEstimate VARCHAR(100) NOT NULL DEFAULT '0',
+  vaccinatedCount     INT NOT NULL DEFAULT 0,
+  dayPreference       VARCHAR(100) NOT NULL DEFAULT '',
+  referralSource      VARCHAR(50) NOT NULL DEFAULT '',
+  referralOther       VARCHAR(255) NOT NULL DEFAULT '',
   dateAdded           DATE DEFAULT NULL
 );
 


### PR DESCRIPTION
…oval flow

- New public registration page (pages/RegisterTeam/) replacing the external Google Form link, capturing all 10 confirmed fields and inserting into pending_teams with status=Pending
- Redesigned admin Team's Overview page with Active/Pending tabs; Pending tab shows full registration data with Approve/Reject actions
- Approve flow (library/teams.cfc) creates the team + captain player record (or links to an existing player) and removes the pending row, wrapped in a transaction
- Duplicate-captain detection on Approve: searches players by exact name/ phone match and lets admin link an existing player instead of creating a duplicate, showing division name and other identifying fields
- pending_teams schema updated to match the real form fields (schema.sql)

<img width="1897" height="857" alt="image" src="https://github.com/user-attachments/assets/77063b9f-67bf-4841-b5be-2de4a18c2f97" />
<img width="1898" height="863" alt="image" src="https://github.com/user-attachments/assets/f1b15e62-bb73-493d-b817-fbfb80f9fccb" />
<img width="1895" height="857" alt="image" src="https://github.com/user-attachments/assets/7d4fc2fa-ac81-40ed-a9fc-b35cbe2c7fee" />
<img width="1903" height="848" alt="image" src="https://github.com/user-attachments/assets/e17ff2c5-9bce-4650-a7a8-ae699dc27784" />
<img width="1917" height="807" alt="image" src="https://github.com/user-attachments/assets/02e51522-b92e-4dc9-8e16-3820049064e4" />
<img width="1896" height="852" alt="image" src="https://github.com/user-attachments/assets/2c3d5a01-74c1-463b-9276-740ed8f335f3" />

