### PR TITLE
Redesign team registration page with modern card layout

### DIFF
--- a/pages/RegisterTeam/registerTeam.cfm
+++ b/pages/RegisterTeam/registerTeam.cfm
@@ -15,169 +15,164 @@
 	<cfexit>
 </cfif>
 
-<div class="main" style="background-color: white;">
+<div class="main team-reg-wrapper">
     <div class="section text-center">
       <div class="container">
 
         <!--- Content Here --->
 		<div class="wrapper">
 		    <div class="profile-content section" style="padding-top: 20px">
-		      <div class="container" style="padding-bottom: 20px">
-		      </div>
 
 		      <div class="container">
 		        <div class="row">
-		          <div class="col-md-6 ml-auto mr-auto">
-		            <h3 class="description">Register Your Team</h3>
+		          <div class="col-lg-10 ml-auto mr-auto">
+		            <div class="team-reg-header">
+		              <h3 class="description">Register Your Team</h3>
+		              <p>Fill out the form below to get your team signed up for the season</p>
+		            </div>
 		            <form class="settings-form" method="POST">
 
-		              <div class="form-group">
-		                <label>Team Name</label>
-		                <input type="text" required class="form-control border-input" placeholder="Team Name" name="teamName">
-		              </div>
+		              <div class="questions-grid">
 
-		              <div class="row">
-			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">Which League are you Interested in Joining?</label>
-			              		<cfloop list="#leagueOptions#" index="i" item="x">
-						            <div class="form-check-radio">
-						              <label class="form-check-label">
-						                <input class="form-check-input" type="radio" required name="selectedDivision" value="#x#"> #x#
-						                <span class="form-check-sign"></span>
-						              </label>
-						            </div>
-					        	</cfloop>
-			              		</div>
-		              </div>
+		                <div class="question-card full-width">
+		                  <label>Team Name</label>
+		                  <input type="text" required class="form-control border-input" placeholder="Team Name" name="teamName">
+		                </div>
 
-		              <div class="row">
-			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">Is everyone on your team over 18?</label>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input" type="radio" required name="allPlayersOver18" value="Yes"> Yes
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input" type="radio" required name="allPlayersOver18" value="No"> No
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              </div>
-		              </div>
+		                <div class="question-card">
+		                  <label class="biggerLabel">Which League are you Interested in Joining?</label>
+		                  <cfloop list="#leagueOptions#" index="i" item="x">
+		                    <div class="form-check-radio">
+		                      <label class="form-check-label">
+		                        <input class="form-check-input" type="radio" required name="selectedDivision" value="#x#"> #x#
+		                        <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                      </label>
+		                    </div>
+		                  </cfloop>
+		                </div>
 
-		              <div class="form-group">
-		                <label>Team Captain/Manager's Name</label>
-		                <input type="text" required class="form-control border-input" placeholder="Captain/Manager's Name" name="captainName">
-		              </div>
+		                <div class="question-card">
+		                  <label class="biggerLabel">Is everyone on your team over 18?</label>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input" type="radio" required name="allPlayersOver18" value="Yes"> Yes
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input" type="radio" required name="allPlayersOver18" value="No"> No
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                </div>
 
-		              <div class="form-group">
-		                <label>Team Manager's Phone Number</label>
-		                <input type="tel" required id="teamPhoneField" class="form-control border-input" name="phoneNumber" placeholder="123-456-7890">
-		              </div>
+		                <div class="question-card">
+		                  <label>Team Captain/Manager's Name</label>
+		                  <input type="text" required class="form-control border-input" placeholder="Captain/Manager's Name" name="captainName">
+		                </div>
 
-		              <div class="form-group">
-		                <label>Team Manager's Email</label>
-		                <input type="email" required class="form-control border-input" name="email" placeholder="Email">
-		              </div>
+		                <div class="question-card">
+		                  <label>Team Manager's Phone Number</label>
+		                  <input type="tel" required id="teamPhoneField" class="form-control border-input" name="phoneNumber" placeholder="123-456-7890">
+		                </div>
 
-		              <div class="row">
-			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">Player Count</label>
-			              		<cfloop list="#playerCountOptions#" index="i" item="x">
-						            <div class="form-check-radio">
-						              <label class="form-check-label">
-						                <input class="form-check-input" type="radio" required name="playerCountEstimate" value="#x#"> #x#
-						                <span class="form-check-sign"></span>
-						              </label>
-						            </div>
-					        	</cfloop>
-			              </div>
-		              </div>
+		                <div class="question-card full-width">
+		                  <label>Team Manager's Email</label>
+		                  <input type="email" required class="form-control border-input" name="email" placeholder="Email">
+		                </div>
 
-		              <div class="row">
-			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">Team's Overall Level of Experience</label>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="1"> 1 - Recreational
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="2"> 2 - High School Varsity
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="3"> 3 - College
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="4"> 4 - D-1 University
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input" type="radio" required name="highestLevel" value="5"> 5 - Professional
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              </div>
-		              </div>
+		                <div class="question-card">
+		                  <label class="biggerLabel">Player Count</label>
+		                  <cfloop list="#playerCountOptions#" index="i" item="x">
+		                    <div class="form-check-radio">
+		                      <label class="form-check-label">
+		                        <input class="form-check-input" type="radio" required name="playerCountEstimate" value="#x#"> #x#
+		                        <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                      </label>
+		                    </div>
+		                  </cfloop>
+		                </div>
 
-		              <div class="row">
-			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">Preference for League Days</label>
-			              		<cfloop list="#dayOptions#" index="i" item="x">
-						            <div class="form-check">
-						              <label class="form-check-label">
-						                <input class="form-check-input" type="checkbox" name="dayPreference" value="#x#"> #x#
-						                <span class="form-check-sign"></span>
-						              </label>
-						            </div>
-					        	</cfloop>
-			              </div>
-		              </div>
+		                <div class="question-card">
+		                  <label class="biggerLabel">Team's Overall Level of Experience</label>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input" type="radio" required name="highestLevel" value="1"> 1 - Recreational
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input" type="radio" required name="highestLevel" value="2"> 2 - High School Varsity
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input" type="radio" required name="highestLevel" value="3"> 3 - College
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input" type="radio" required name="highestLevel" value="4"> 4 - D-1 University
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input" type="radio" required name="highestLevel" value="5"> 5 - Professional
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                </div>
 
-		              <div class="row">
-			              <div class="col-md-12 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">How did you hear about us?</label>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Friends"> Friends
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Instagram"> Instagram
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Website"> Website
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-check-radio">
-			              		  <label class="form-check-label">
-			              		    <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Other"> Other
-			              		    <span class="form-check-sign"></span>
-			              		  </label>
-			              		</div>
-			              		<div class="form-group" id="referralOtherItem" style="display:none;">
-			              		  <input type="text" class="form-control border-input" placeholder="Please specify" name="referralOther" id="referralOtherInput">
-			              		</div>
-			              </div>
+		                <div class="question-card full-width">
+		                  <label class="biggerLabel">Preference for League Days</label>
+		                  <div class="day-options">
+		                    <cfloop list="#dayOptions#" index="i" item="x">
+		                      <div class="form-check">
+		                        <label class="form-check-label">
+		                          <input class="form-check-input" type="checkbox" name="dayPreference" value="#x#"> #x#
+		                          <span class="form-check-sign"></span>
+		                        </label>
+		                      </div>
+		                    </cfloop>
+		                  </div>
+		                </div>
+
+		                <div class="question-card full-width">
+		                  <label class="biggerLabel">How did you hear about us?</label>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Friends"> Friends
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Instagram"> Instagram
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Website"> Website
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-check-radio">
+		                    <label class="form-check-label">
+		                      <input class="form-check-input referralRadio" type="radio" required name="referralSource" value="Other"> Other
+		                      <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                    </label>
+		                  </div>
+		                  <div class="form-group" id="referralOtherItem" style="display:none;">
+		                    <input type="text" class="form-control border-input" placeholder="Please specify" name="referralOther" id="referralOtherInput">
+		                  </div>
+		                </div>
+
 		              </div>
 
 		              <input type="hidden" name="registerTeamSubmit" value="1">
@@ -185,7 +180,7 @@
 		              <div class="text-center errorDiv">
 		                <span class="errorMessage"></span>
 		              </div>
-		              <div class="text-center">
+		              <div class="text-center" style="margin-top: 1.5rem;">
 		                <button type="submit" class="btn btn-wd btn-info btn-round saveBtn">Submit Registration</button>
 		              </div>
 		            </form>

--- a/pages/RegisterTeam/registerTeam.css
+++ b/pages/RegisterTeam/registerTeam.css
@@ -1,7 +1,158 @@
-.nonTextQuestions {
-  padding: 10px;
+/* ==========================================================================
+   Team Registration - modern layout
+   Palette matches the rest of the site (Teams / Stats / Player Profiles)
+   ========================================================================== */
+
+.team-reg-wrapper {
+  background: linear-gradient(180deg, #faf9f7 0%, #f5f4f2 100%);
+  padding: 10px 0 40px;
 }
 
+.team-reg-header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.team-reg-header h3.description {
+  color: #403d39;
+  font-weight: 700;
+  display: inline-block;
+  border-bottom: 3px solid #f5593d;
+  padding-bottom: 10px;
+  margin-bottom: 0.5rem;
+}
+
+.team-reg-header p {
+  color: #66615b;
+  margin-bottom: 0;
+}
+
+/* ---- Grid of question cards ---- */
+.questions-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  align-items: start;
+}
+
+@media (min-width: 768px) {
+  .questions-grid {
+    grid-template-columns: 1fr 1fr;
+  }
+
+  .questions-grid .full-width {
+    grid-column: 1 / -1;
+  }
+}
+
+.question-card {
+  background: linear-gradient(180deg, #ffffff 0%, #faf9f7 100%);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow:
+    0 2px 16px rgba(0, 0, 0, 0.06),
+    0 1.5px 4px rgba(0, 0, 0, 0.03);
+  text-align: left;
+}
+
+.question-card .biggerLabel,
+.question-card label:not(.form-check-label) {
+  color: #403d39;
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+/* ---- Text inputs ---- */
+.question-card .form-control.border-input {
+  border: 1px solid #e8e6e3;
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.9rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.question-card .form-control.border-input:focus {
+  border-color: #f5593d;
+  box-shadow: 0 0 0 3px rgba(245, 89, 61, 0.12);
+}
+
+/* ---- Radio choices styled as basketballs ---- */
+.form-check-radio .form-check-sign {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  left: 0;
+  top: -3px;
+  width: 24px;
+  height: 24px;
+}
+
+.form-check-radio .form-check-sign::before,
+.form-check-radio .form-check-sign::after,
+.form-check-radio input[type="radio"] + .form-check-sign::after,
+.form-check-radio input[type="radio"]:checked + .form-check-sign::after,
+.form-check-radio input[type="radio"]:checked ~ .form-check-sign::after {
+  content: none !important;
+  display: none !important;
+}
+
+.form-check-radio .form-check-sign i.basketball-icon {
+  font-size: 20px;
+  color: #d7d3cf;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.form-check-radio input[type="radio"]:checked ~ .form-check-sign i.basketball-icon {
+  color: #f5593d;
+  transform: scale(1.15);
+}
+
+.form-check-radio .form-check-label:hover .form-check-sign i.basketball-icon {
+  color: #f5a087;
+}
+
+.form-check-radio input[type="radio"]:checked ~ .form-check-sign ~ .form-check-label,
+.form-check-radio .form-check-label {
+  color: #403d39;
+}
+
+/* ---- Day preference checkboxes (recolored, not basketballs) ---- */
+.form-check .form-check-sign::before,
+.form-check .form-check-sign::after {
+  border-radius: 6px;
+}
+
+.form-check input[type="checkbox"]:checked ~ .form-check-sign::before {
+  background-color: #f5593d;
+}
+
+.form-check .form-check-label:hover .form-check-sign::before {
+  background-color: #c9c5c1;
+}
+
+.form-check input[type="checkbox"]:checked ~ .form-check-sign:hover::before {
+  background-color: #e04a30;
+}
+
+/* ---- Day options laid out as a friendly row ---- */
+.day-options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.5rem;
+}
+
+.day-options .form-check {
+  margin-bottom: 8px;
+}
+
+/* ---- Referral "other" field ---- */
+#referralOtherItem {
+  margin-top: 0.5rem;
+}
+
+/* ---- Misc ---- */
 h3.description {
   color: #333;
 }
@@ -22,4 +173,14 @@ h3.description {
 
 label {
   font-weight: 600;
+}
+
+.saveBtn {
+  background: linear-gradient(135deg, #f5593d 0%, #e04a30 100%);
+  border: none;
+}
+
+.saveBtn:hover,
+.saveBtn:focus {
+  background: linear-gradient(135deg, #e04a30 0%, #d9442a 100%);
 }


### PR DESCRIPTION
- Each question now sits in its own card, arranged in a responsive two-column grid
- Radio choices use a basketball icon in place of the default dot, filling orange when selected
- League day checkboxes turn brand orange (#f5593d) when checked
- Styling matches the palette/card look already used on Teams, Stats, and Player Profile pages

<img width="1900" height="868" alt="image" src="https://github.com/user-attachments/assets/0f3b45b1-fcfc-4443-97d3-3fcb8f100084" />
<img width="1897" height="867" alt="image" src="https://github.com/user-attachments/assets/cfde87f2-1ae6-490d-94fe-94337070a430" />
<img width="1897" height="866" alt="image" src="https://github.com/user-attachments/assets/0ba12c04-0149-4f84-92e1-1eb969e48a04" />
