### PR TITLE
Redesign player registration page with modern card layout

### DIFF
--- a/pages/Register/register.cfm
+++ b/pages/Register/register.cfm
@@ -2,7 +2,7 @@
 
 <!--- Page Specific CSS/JS Here --->
 <link href="https://demos.creative-tim.com/paper-kit-2-pro/assets/css/paper-kit.min.css?v=2.3.1" rel="stylesheet">
-<link href="../Register/register.css?v=1.2" rel="stylesheet">
+<link href="../Register/register.css?v=1.3" rel="stylesheet">
 
 <cfoutput>
 
@@ -31,7 +31,7 @@
 </cfif>
 
 
-<div class="main" style="background-color: white;">
+<div class="main player-reg-wrapper">
     <div class="section text-center">
       <div class="container">
 
@@ -45,7 +45,7 @@
                     </button>
                     <h5 class="modal-title text-center" id="exampleModalLabel">ATHLETIC WAIVER AND RELEASE OF LIABILITY</h5>
                   </div>
-                  <div class="modal-body"> 
+                  <div class="modal-body">
 
                   	<p><b>READ BEFORE SIGNING</b></p>
 
@@ -78,7 +78,7 @@ I, for myself and on behalf of my heirs, assigns, personal representatives and n
                     </button>
                     <h5 class="modal-title text-center" id="exampleModalLabel">PHOTO/VIDEO CONSENT FORM</h5>
                   </div>
-                  <div class="modal-body"> 
+                  <div class="modal-body">
 
                   	<p><b>READ BEFORE SIGNING</b></p>
 
@@ -104,242 +104,234 @@ I, for myself and on behalf of my heirs, assigns, personal representatives and n
 					</div>
 		      </div>
 
-
-
 		      <div class="container">
 		        <div class="row">
-		          <div class="col-md-6 ml-auto mr-auto">
+		          <div class="col-lg-10 ml-auto mr-auto">
+		            <div class="player-reg-header">
+		              <h3 class="description">Register as a Player</h3>
+		              <p>Fill out the form below to create your player profile for the season</p>
+		            </div>
 		            <form class="settings-form" method="POST">
 
-	                  <div class="form-group">
-	                    <label class="teamSelect">Select Season</label><br>
-						<select class="seasonSelect" name="seasonSelect" style="padding: 7px;">
-						  <option value=""></option>
-						  <option value="#getCurrentSeason.seasonID#">#getCurrentSeason.seasonName#</option>
-						</select>
-	                  </div>
-	                  <div class="form-group">
-	                    <label>Gender</label><br>
-						<select class="gender" name="gender" style="padding: 7px;">
-						  <option value=""></option>
-						  <option value="Male">Male</option>
-						  <option value="Female">Female</option>
-						</select>
-	                  </div>
-		              <div class="form-group">
-		                <label>Email</label>
-		                <input type="email" required class="form-control border-input" placeholder="Email" name="email">
-		              </div>
-		              <div class="form-group">
-		                <label>Password</label>
-		                <input type="password" required class="form-control border-input" placeholder="Password" name="password">
-		              </div>
-		              <div class="row">
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>First Name</label>
-		                    <input type="text" required class="form-control border-input" placeholder="First Name" name="firstName">
-		                  </div>
+		              <div class="questions-grid">
+		                <div class="question-card full-width">
+		                  <label class="teamSelect">Select Season</label>
+		                  <select class="seasonSelect" name="seasonSelect">
+		                    <option value=""></option>
+		                    <option value="#getCurrentSeason.seasonID#">#getCurrentSeason.seasonName#</option>
+		                  </select>
 		                </div>
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>Last Name</label>
-		                    <input type="text" required class="form-control border-input" placeholder="Last Name" name="lastName">
-		                  </div>
+
+		                <div class="question-card full-width">
+		                  <label>Gender</label>
+		                  <select class="gender" name="gender">
+		                    <option value=""></option>
+		                    <option value="Male">Male</option>
+		                    <option value="Female">Female</option>
+		                  </select>
 		                </div>
 		              </div>
-		              <div class="row">
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>Birth Date</label>
-		                    <input type="date" required class="form-control border-input" placeholder="Birth Date" name="birthDate">
+
+		              <div class="row field-split">
+		                <div class="col-md-6">
+		                  <div class="field-column">
+		                    <div class="question-card">
+		                      <label>Email</label>
+		                      <input type="email" required class="form-control border-input" placeholder="Email" name="email">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Password</label>
+		                      <input type="password" required class="form-control border-input" placeholder="Password" name="password">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>First Name</label>
+		                      <input type="text" required class="form-control border-input" placeholder="First Name" name="firstName">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Last Name</label>
+		                      <input type="text" required class="form-control border-input" placeholder="Last Name" name="lastName">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Birth Date</label>
+		                      <input type="date" required class="form-control border-input" placeholder="Birth Date" name="birthDate">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Phone Number</label>
+		                      <input type="tel" required id="phoneField" class="form-control border-input" name="phone" placeholder="123-45-678">
+		                    </div>
 		                  </div>
 		                </div>
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>Phone Number</label>
-		                    <input type="tel" required id="phoneField" class="form-control border-input" name="phone" placeholder="123-45-678" required>
-		                  </div>
-		                </div>
-		              </div>
-		              <div class="row">
-		                <div class="col-md-6 ml-auto mr-auto nonTextQuestions">
-		                  <div class="form-group">
-		                    <label>Zip Code</label>
-		                    <input type="text" required class="form-control border-input" placeholder="Zip Code" name="zipCode" maxlength="5">
-		                  </div>
-		                </div>
-		              </div>
-		              <div class="row">
-		                <div class="col-md-6 ml-auto mr-auto nonTextQuestions">
-		                  <div class="form-group">
-		                    <label>Instagram Handle (No @ Needed)</label>
-		                    <input type="text" class="form-control border-input" placeholder="IG Handle" name="instagram">
-		                  </div>
-		                </div>
-		              </div>
-		              <div class="row">
-		                <div class="col-md-6 ml-auto mr-auto nonTextQuestions">
-		                  <div class="form-group">
-		                    <label>Confirmed Jersey Number (Only fill out if you currently have an existing jersey)</label>
-		                    <input type="number" class="form-control border-input" name="currentJersey">
-		                  </div>
-		                </div>
-		              </div>
-		              <div class="row">
-			              <div class="col-md-6 ml-auto mr-auto nonTextQuestions">
-			                  <div class="form-group">
-			                    <label class="teamSelect">Select Team (Will be verified by Team Captain)</label><br>
-								<select class="teamID" name="teamID" style="padding: 7px;">
-								  <option value=""></option>
-								  <cfloop query="getTeams">
-								  	<option value="#getTeams.TeamID#">#getTeams.TeamName#</option>
-								  </cfloop>
-								  <option value="0">I am signing up as a free agent</option>
-								</select>
-								<!--- <br>
-								<b>If you have a team but do not see it here, please register at a later time once your team has been added.</b> --->
-			                  </div>
-			               </div>
-		              </div>
-		              <div class="row">
-			              <div class="col-md-6 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">Basketball Experience</label>
-			              		<cfloop list="#basketballExp#" index="i" item="x">
-						            <div class="form-check-radio">
-						              <label class="form-check-label">
-						                <input class="form-check-input" type="radio" name="highestLevel" value="#x#"> #x#
-						                <span class="form-check-sign"></span>
-						              </label>
-						            </div>
-					        	</cfloop>
-		              		</div>
-		              </div>
-		              <div class="row">
-			              <div class="col-md-6 ml-auto mr-auto nonTextQuestions">
-			              		<label class="biggerLabel">Position</label>
-			              		<cfloop list="#bballPosition#" index="i" item="x">
-						            <div class="form-check-radio">
-						              <label class="form-check-label">
-						                <input class="form-check-input" type="radio" name="position" value="#x#"> #x#
-						                <span class="form-check-sign"></span>
-						              </label>
-						            </div>
-					        	</cfloop>
-		              		</div>
-		              </div>
-		              <div class="row">
-			              <div class="col-md-6 ml-auto mr-auto nonTextQuestions">
-			                  <div class="form-group">
-			                    <label>Height</label><br>
-								<select name="height" style="padding: 7px;">
-								  <cfloop list="#heightOptions#" index="i" item="x">
-								  	<option value="#x#">#x#</option>
-								  </cfloop>
-								</select>
-			                  </div>
-			               </div>
-		              </div>
-		              <div class="row">
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>Weight</label>
-		                    <input type="number" class="form-control border-input" placeholder="Weight" name="weight">
-		                  </div>
-		                </div>
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>Hometown</label>
-		                    <input type="text" class="form-control border-input" placeholder="Hometown" name="hometown">
-		                  </div>
-		                </div>
-		              </div>
-		              <div class="row">
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>Last School Attended</label>
-		                    <input type="text" class="form-control border-input" placeholder="Last School Attended" name="school">
-		                  </div>
-		                </div>
-		                <div class="col-md-6 col-sm-6">
-		                  <div class="form-group">
-		                    <label>Current City</label>
-		                    <input type="text" class="form-control border-input" name="currentCity">
+		                <div class="col-md-6">
+		                  <div class="field-column">
+		                    <div class="question-card">
+		                      <label>Height</label>
+		                      <select name="height">
+		                        <cfloop list="#heightOptions#" index="i" item="x">
+		                          <option value="#x#">#x#</option>
+		                        </cfloop>
+		                      </select>
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Weight</label>
+		                      <input type="number" class="form-control border-input" placeholder="Weight" name="weight">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Hometown</label>
+		                      <input type="text" class="form-control border-input" placeholder="Hometown" name="hometown">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Last School Attended</label>
+		                      <input type="text" class="form-control border-input" placeholder="Last School Attended" name="school">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Current City</label>
+		                      <input type="text" class="form-control border-input" name="currentCity">
+		                    </div>
+		                    <div class="question-card">
+		                      <label>Zip Code</label>
+		                      <input type="text" required class="form-control border-input" placeholder="Zip Code" name="zipCode" maxlength="5">
+		                    </div>
 		                  </div>
 		                </div>
 		              </div>
 
-	                  <!--- <div class="form-group">
-						  Are you over 18?
-						 <input class="registerRadio firstRadio" type="radio" name="over18" value="1"> Yes
-						 <input class="registerRadio secondRadio" type="radio" name="over18" value="0"> No
-                	  </div> --->
-		              <!--- <div class="form-group">
-		                <label>Description</label>
-		                <textarea class="form-control textarea-limited" placeholder="This is a textarea limited to 150 characters." rows="3" maxlength="150"></textarea>
-		                <h5><small><span id="textarea-limited-message" class="pull-right">150 characters left</span></small></h5>
+		              <div class="questions-grid">
+
+		                <div class="question-card full-width">
+		                  <label class="biggerLabel">Basketball Experience</label>
+		                  <div class="option-row">
+		                    <cfloop list="#basketballExp#" index="i" item="x">
+		                      <div class="form-check-radio">
+		                        <label class="form-check-label">
+		                          <input class="form-check-input" type="radio" name="highestLevel" value="#x#"> #x#
+		                          <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                        </label>
+		                      </div>
+		                    </cfloop>
+		                  </div>
+		                </div>
+
+		                <div class="question-card full-width">
+		                  <label class="biggerLabel">Position</label>
+		                  <div class="option-row">
+		                    <cfloop list="#bballPosition#" index="i" item="x">
+		                      <div class="form-check-radio">
+		                        <label class="form-check-label">
+		                          <input class="form-check-input" type="radio" name="position" value="#x#"> #x#
+		                          <span class="form-check-sign"><i class="fa-solid fa-basketball basketball-icon"></i></span>
+		                        </label>
+		                      </div>
+		                    </cfloop>
+		                  </div>
+		                </div>
+
+		                <div class="question-card">
+		                  <label>Instagram Handle (No @ Needed)</label>
+		                  <input type="text" class="form-control border-input" placeholder="IG Handle" name="instagram">
+		                </div>
+
+		                <div class="question-card">
+		                  <label>Confirmed Jersey Number (Only fill out if you currently have an existing jersey)</label>
+		                  <input type="number" class="form-control border-input" name="currentJersey">
+		                </div>
+
+		                <div class="question-card full-width">
+		                  <label class="teamSelect">Select Team (Will be verified by Team Captain)</label>
+		                  <select class="teamID" name="teamID">
+		                    <option value=""></option>
+		                    <cfloop query="getTeams">
+		                      <option value="#getTeams.TeamID#">#getTeams.TeamName#</option>
+		                    </cfloop>
+		                    <option value="0">I am signing up as a free agent</option>
+		                  </select>
+		                </div>
+
+		                <div class="question-card">
+		                  <ul class="notifications">
+		                    <li class="notification-item">
+		                      <strong>Are you the captain of this team?</strong>
+		                      <input type="checkbox" name="captainCheck" data-toggle="switch" data-on-color="info" data-off-color="default"><span class="toggle"></span>
+		                    </li>
+		                  </ul>
+		                </div>
+
+		                <div class="question-card">
+		                  <ul class="notifications">
+		                    <li class="notification-item">
+		                      Are you over 18?
+		                      <input type="checkbox" name="over18" data-toggle="switch" checked="" data-on-color="info" data-off-color="default"><span class="toggle"></span>
+		                    </li>
+		                  </ul>
+		                </div>
+
+		                <div class="question-card">
+		                  <ul class="notifications">
+		                    <li class="notification-item">
+		                      Are you a free agent?
+		                      <input type="checkbox" name="freeAgent" data-toggle="switch" checked="" data-on-color="info" data-off-color="default"><span class="toggle"></span>
+		                    </li>
+		                  </ul>
+		                </div>
+
+		                <div class="question-card">
+		                  <ul class="notifications">
+		                    <li class="notification-item">
+		                      Do we have your permission to share above information on our website for Player Profiles?
+		                      <input type="checkbox" name="permissionToShare" data-toggle="switch" checked="" data-on-color="info" data-off-color="default"><span class="toggle"></span>
+		                    </li>
+		                  </ul>
+		                </div>
+
+		                <div class="question-card">
+		                  <ul class="notifications">
+		                    <li class="notification-item">
+		                      Do you wish to play in the Master's League? (Age 40+)
+		                      <input type="checkbox" name="mastersLeague" data-toggle="switch" data-on-color="info" data-off-color="default"><span class="toggle"></span>
+		                    </li>
+		                  </ul>
+		                </div>
+
+		                <div class="question-card full-width">
+		                  <label class="biggerLabel">Waivers &amp; Consent</label>
+		                  <button type="button" class="btn btn-outline-danger btn-round modalBtn" data-toggle="modal" data-target="##waiverModal">
+		                    Athletic Waiver
+		                  </button>
+		                  <button type="button" class="btn btn-outline-danger btn-round modalBtn" data-toggle="modal" data-target="##photoModal">
+		                    Photo/Video Waiver
+		                  </button>
+		                  <ul class="notifications acknowledged">
+		                    <li class="notification-item">
+		                      I have acknowledged, read, and agreed to the terms of the Athletic Waiver.
+		                        <div class="form-check">
+		                          <label class="form-check-label">
+		                            <input class="form-check-input waiverCheck" type="checkbox" value="1" name="athleticWaiver">
+		                            <span class="form-check-sign"></span>
+		                          </label>
+		                        </div>
+		                    </li>
+		                    <li class="notification-item">
+		                      I have acknowledged, read, and agreed to the terms of the Photo/Video Waiver.
+		                        <div class="form-check">
+		                          <label class="form-check-label">
+		                            <input class="form-check-input waiverCheck" type="checkbox" value="1" name="photoWaiver">
+		                            <span class="form-check-sign"></span>
+		                          </label>
+		                        </div>
+		                    </li>
+		                    <li class="notification-item" id="guardianAckItem" style="display:none;">
+		                      I confirm that I am the parent or legal guardian of this player and am registering on their behalf.
+		                        <div class="form-check">
+		                          <label class="form-check-label">
+		                            <input class="form-check-input" type="checkbox" value="1" name="guardianAck" id="guardianAck">
+		                            <span class="form-check-sign"></span>
+		                          </label>
+		                        </div>
+		                    </li>
+		                  </ul>
+		                </div>
+
 		              </div>
-		              <label>Notifications</label> ---> 
-		              <ul class="notifications">
-		                <li class="notification-item">
-		                  <strong>Are you the captain of this team?</strong>
-		                  <input type="checkbox" name="captainCheck" data-toggle="switch" data-on-color="info" data-off-color="info"><span class="toggle"></span>
-		                </li>
-		                <li class="notification-item">
-		                  Are you over 18?
-		                  <input type="checkbox" name="over18" data-toggle="switch" checked="" data-on-color="info" data-off-color="info"><span class="toggle"></span>
-		                </li>
-		                <li class="notification-item">
-		                  Are you a free agent?
-		                  <input type="checkbox" name="freeAgent" data-toggle="switch" checked="" data-on-color="info" data-off-color="info"><span class="toggle"></span>
-		                </li>
-		                <li class="notification-item">
-		                  Do we have your permission to share above information on our website for Player Profiles?
-		                  <input type="checkbox" name="permissionToShare" data-toggle="switch" checked="" data-on-color="info" data-off-color="info"><span class="toggle"></span>
-		                </li>
-		                <li class="notification-item">
-		                  Do you wish to play in the Master's League? (Age 40+)
-		                  <input type="checkbox" name="mastersLeague" data-toggle="switch" data-on-color="info" data-off-color="info"><span class="toggle"></span>
-		                </li>
-		                <li class="notification-item">
-		                	<!--- Divider --->
-		                </li>
-		              </ul>
-		            <button type="button" class="btn btn-outline-danger btn-round modalBtn" data-toggle="modal" data-target="##waiverModal">
-		              Athletic Waiver
-		            </button>
-		            <button type="button" class="btn btn-outline-danger btn-round modalBtn" data-toggle="modal" data-target="##photoModal">
-		              Photo/Video Waiver
-		            </button>
-		              <ul class="notifications acknowledged">
-		                <li class="notification-item">
-		                  I have acknowledged, read, and agreed to the terms of the Athletic Waiver.
-				            <div class="form-check">
-				              <label class="form-check-label">
-				                <input class="form-check-input waiverCheck" type="checkbox" value="1" name="athleticWaiver">
-				                <span class="form-check-sign"></span>
-				              </label>
-				            </div>
-		                </li>
-		                <li class="notification-item">
-		                  I have acknowledged, read, and agreed to the terms of the Photo/Video Waiver.
-				            <div class="form-check">
-				              <label class="form-check-label">
-				                <input class="form-check-input waiverCheck" type="checkbox" value="1" name="photoWaiver">
-				                <span class="form-check-sign"></span>
-				              </label>
-				            </div>
-		                </li>
-		                <li class="notification-item" id="guardianAckItem" style="display:none;">
-		                  I confirm that I am the parent or legal guardian of this player and am registering on their behalf.
-				            <div class="form-check">
-				              <label class="form-check-label">
-				                <input class="form-check-input" type="checkbox" value="1" name="guardianAck" id="guardianAck">
-				                <span class="form-check-sign"></span>
-				              </label>
-				            </div>
-		                </li>
-		              </ul>
+
 		              <div class="text-center errorDiv">
 		                <span class="errorMessage"></span>
 		              </div>
@@ -353,10 +345,10 @@ I, for myself and on behalf of my heirs, assigns, personal representatives and n
 		    </div>
 		  </div>
 
-		      </div>
-		    </div>
 		</div>
+	    </div>
+	</div>
 </cfoutput>
 
 <cfinclude template="/footer.cfm">
-<script src="../Register/register.js?v=1.2"></script>
+<script src="../Register/register.js?v=1.3"></script>

--- a/pages/Register/register.css
+++ b/pages/Register/register.css
@@ -1,99 +1,238 @@
-.registerRadio {
-  transform: scale(1.5);
+/* ==========================================================================
+   Player Registration - modern layout
+   Matches the card system introduced on Team Registration
+   (#f5593d brand orange, .question-card / .questions-grid, basketball
+   radio icons, orange-fill checkboxes)
+   ========================================================================== */
+
+.player-reg-wrapper {
+  background: linear-gradient(180deg, #faf9f7 0%, #f5f4f2 100%);
+  padding: 10px 0 40px;
 }
 
-.firstRadio {
-  margin-left: 20px;
-}
-
-.secondRadio {
-  margin-left: 10px;
-}
-
-.nonTextQuestions {
-  padding: 10px;
-}
-
-.modalBtn {
-  margin-bottom: 20px;
-}
-
-.biggerLabel {
-  font-size: large;
-}
-
-ul.acknowledge {
-  float: none;
-}
-
-/* Snackbar */
-#snackbar {
-  visibility: hidden;
-  min-width: 250px;
-  margin-left: -125px;
-  background-color: #333;
-  color: #fff;
+.player-reg-header {
   text-align: center;
-  border-radius: 2px;
-  padding: 16px;
-  position: fixed;
-  z-index: 100;
-  left: 50%;
-  bottom: 30px;
-  font-size: 17px;
+  margin-bottom: 2rem;
 }
 
-#snackbar.show {
-  visibility: visible;
-  -webkit-animation: fadein 0.5s, fadeout 0.5s 2.5s;
-  animation: fadein 0.5s, fadeout 0.5s 2.5s;
+.player-reg-header h3.description {
+  color: #403d39;
+  font-weight: 700;
+  display: inline-block;
+  border-bottom: 3px solid #f5593d;
+  padding-bottom: 10px;
+  margin-bottom: 0.5rem;
 }
 
-@-webkit-keyframes fadein {
-  from {
-    bottom: 0;
-    opacity: 0;
-  }
-  to {
-    bottom: 30px;
-    opacity: 1;
-  }
+.player-reg-header p {
+  color: #66615b;
+  margin-bottom: 0;
 }
 
-@keyframes fadein {
-  from {
-    bottom: 0;
-    opacity: 0;
-  }
-  to {
-    bottom: 30px;
-    opacity: 1;
-  }
+/* ---- Grid of question cards ---- */
+.questions-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1.25rem;
+  align-items: start;
+  margin-bottom: 1.25rem;
 }
 
-@-webkit-keyframes fadeout {
-  from {
-    bottom: 30px;
-    opacity: 1;
+@media (min-width: 768px) {
+  .questions-grid {
+    grid-template-columns: 1fr 1fr;
   }
-  to {
-    bottom: 0;
-    opacity: 0;
+
+  .questions-grid .full-width {
+    grid-column: 1 / -1;
   }
 }
 
-@keyframes fadeout {
-  from {
-    bottom: 30px;
-    opacity: 1;
-  }
-  to {
-    bottom: 0;
-    opacity: 0;
+.question-card {
+  background: linear-gradient(180deg, #ffffff 0%, #faf9f7 100%);
+  border-radius: 1rem;
+  padding: 1.25rem 1.5rem;
+  box-shadow:
+    0 2px 16px rgba(0, 0, 0, 0.06),
+    0 1.5px 4px rgba(0, 0, 0, 0.03);
+  text-align: left;
+}
+
+.question-card .biggerLabel,
+.question-card label:not(.form-check-label) {
+  color: #403d39;
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+  display: block;
+}
+
+/* ---- Text inputs / selects ---- */
+.question-card .form-control.border-input,
+.question-card select {
+  border: 1px solid #e8e6e3;
+  border-radius: 0.5rem;
+  padding: 0.6rem 0.9rem;
+  width: 100%;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.question-card .form-control.border-input:focus,
+.question-card select:focus {
+  border-color: #f5593d;
+  box-shadow: 0 0 0 3px rgba(245, 89, 61, 0.12);
+  outline: none;
+}
+
+.question-card .teamSelect {
+  color: #403d39;
+}
+
+.question-card .registerRequired {
+  border-color: #e04a30 !important;
+  box-shadow: 0 0 0 3px rgba(224, 74, 48, 0.15);
+}
+
+/* ---- Two-column personal info split ---- */
+.field-split {
+  margin-bottom: 1.25rem;
+}
+
+.field-split .field-column {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.field-split .field-column + .field-column {
+  margin-top: 1.25rem;
+}
+
+@media (min-width: 768px) {
+  .field-split .field-column + .field-column {
+    margin-top: 0;
   }
 }
-/* End Snackbar */
 
+/* ---- Radio choices styled as basketballs ---- */
+.form-check-radio .form-check-sign {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: absolute;
+  left: 0;
+  top: -3px;
+  width: 24px;
+  height: 24px;
+}
+
+.form-check-radio .form-check-sign::before,
+.form-check-radio .form-check-sign::after,
+.form-check-radio input[type="radio"] + .form-check-sign::after,
+.form-check-radio input[type="radio"]:checked + .form-check-sign::after,
+.form-check-radio input[type="radio"]:checked ~ .form-check-sign::after {
+  content: none !important;
+  display: none !important;
+}
+
+.form-check-radio .form-check-sign i.basketball-icon {
+  font-size: 20px;
+  color: #d7d3cf;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.form-check-radio input[type="radio"]:checked ~ .form-check-sign i.basketball-icon {
+  color: #f5593d;
+  transform: scale(1.15);
+}
+
+.form-check-radio .form-check-label:hover .form-check-sign i.basketball-icon {
+  color: #f5a087;
+}
+
+/* ---- Flex-wrap row for radio option lists (Basketball Experience / Position) ---- */
+.option-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 1.5rem;
+}
+
+.option-row .form-check-radio {
+  margin-bottom: 8px;
+}
+
+/* ---- Checkbox fill (Waiver acknowledgments) ---- */
+.form-check .form-check-sign::before,
+.form-check .form-check-sign::after {
+  border-radius: 6px;
+}
+
+.form-check input[type="checkbox"]:checked ~ .form-check-sign::before {
+  background-color: #f5593d;
+}
+
+.form-check .form-check-label:hover .form-check-sign::before {
+  background-color: #c9c5c1;
+}
+
+.form-check input[type="checkbox"]:checked ~ .form-check-sign:hover::before {
+  background-color: #e04a30;
+}
+
+/* ---- Toggle switches (Captain / Over 18 / Free Agent / Permission / Master's) ---- */
+.question-card .notifications {
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: 0;
+}
+
+.question-card .notifications .notification-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.4rem 0;
+}
+
+.bootstrap-switch.bootstrap-switch-info .bootstrap-switch-handle-on.bootstrap-switch-info,
+.bootstrap-switch .bootstrap-switch-handle-on.bootstrap-switch-info {
+  background: #f5593d !important;
+  border-color: #f5593d !important;
+  color: #fff !important;
+}
+
+.bootstrap-switch .bootstrap-switch-handle-off.bootstrap-switch-default {
+  background: #c9c5c1 !important;
+  border-color: #c9c5c1 !important;
+  color: #fff !important;
+}
+
+.bootstrap-switch-label .slider-basketball-icon {
+  font-size: 12px;
+  color: #a8a49f;
+}
+
+/* ---- Waivers & Consent card ---- */
+.question-card .modalBtn {
+  margin-bottom: 0.75rem;
+  margin-right: 0.5rem;
+}
+
+.question-card ul.notifications.acknowledged {
+  margin-top: 1rem;
+}
+
+.question-card ul.notifications.acknowledged .notification-item {
+  display: block;
+  padding: 0.6rem 0;
+  border-top: 1px solid #f5f4f2;
+}
+
+.question-card ul.notifications.acknowledged .notification-item:first-child {
+  border-top: none;
+}
+
+/* ---- Misc ---- */
 .errorDiv {
   padding: 20px;
   font-weight: bold;
@@ -104,23 +243,27 @@ ul.acknowledge {
   font-weight: bold;
 }
 
-.teamSelect {
-  font-size: large;
-  color: red;
-  font-weight: 800;
-}
-
 .registerNote {
   font-weight: bold;
   margin-bottom: 10px;
 }
 
-.registerRequired {
-  border: 3px solid red;
-}
-
 label {
   font-weight: 600;
+}
+
+.saveBtn {
+  background: linear-gradient(135deg, #f5593d 0%, #e04a30 100%);
+  border: none;
+}
+
+.saveBtn:hover,
+.saveBtn:focus {
+  background: linear-gradient(135deg, #e04a30 0%, #d9442a 100%);
+}
+
+.saveBtn:disabled {
+  background: #d7d3cf;
 }
 
 /* Banner Alert Styles */

--- a/pages/Register/register.js
+++ b/pages/Register/register.js
@@ -1,6 +1,7 @@
 $( document ).ready(function() {
 	$('.bootstrap-switch-handle-on').text('Yes');
 	$('.bootstrap-switch-handle-off').text('No');
+	$('.bootstrap-switch-label').html('<i class="fa-solid fa-basketball slider-basketball-icon"></i>');
 
 	function updateSubmitState() {
 		var waiverCount = $('.waiverCheck:checked').length;


### PR DESCRIPTION
- Each question now sits in its own card: Season/Gender up top, a two-column split for contact info vs physical stats, Basketball Experience/Position as flex-wrap basketball-radio rows, and a combined Waivers & Consent card
- Radio choices (Experience, Position) use the basketball-icon selection style from the team registration redesign, filling orange when selected
- Yes/No toggle switches (Captain, Over 18, Free Agent, Permission to Share, Masters League) recolor orange when on and gray when off, with a small basketball icon on the sliding handle
- Waiver/guardian acknowledgment checkboxes fill orange when checked, matching the League Days checkboxes from team registration
- All existing field names, ids, and JS validation/toggle logic preserved unchanged

<img width="1892" height="862" alt="image" src="https://github.com/user-attachments/assets/b30c7876-5b5c-46d2-a516-0a1c68c35919" />
<img width="1893" height="865" alt="image" src="https://github.com/user-attachments/assets/3b50d2dc-6c92-43db-8d94-9ca4042b600c" />
<img width="1901" height="862" alt="image" src="https://github.com/user-attachments/assets/960a6215-9756-4281-941f-1bcff913b6a9" />
<img width="1900" height="867" alt="image" src="https://github.com/user-attachments/assets/d1f66e29-7573-42e6-a2e0-dce1502afa0d" />
